### PR TITLE
chore: add toolchain and formatting options 

### DIFF
--- a/examples/clean_api_demo.rs
+++ b/examples/clean_api_demo.rs
@@ -6,137 +6,110 @@
 use fix_learning::{FixMessage, MsgType, OrdStatus, Side};
 
 fn main() {
-    println!("=== Clean API Demo: No More to_str() Methods! ===\n");
+	println!("=== Clean API Demo: No More to_str() Methods! ===\n");
 
-    // Example 1: Clean enum parsing with FromStr
-    println!("1. Clean Enum Parsing:");
-    let msg_type: MsgType = "D".parse().unwrap();
-    let side: Side = "1".parse().unwrap();
-    let ord_status: OrdStatus = "2".parse().unwrap();
+	// Example 1: Clean enum parsing with FromStr
+	println!("1. Clean Enum Parsing:");
+	let msg_type: MsgType = "D".parse().unwrap();
+	let side: Side = "1".parse().unwrap();
+	let ord_status: OrdStatus = "2".parse().unwrap();
 
-    println!("  Parsed: {:?} -> Display: {}", msg_type, msg_type);
-    println!("  Parsed: {:?} -> Display: {}", side, side);
-    println!("  Parsed: {:?} -> Display: {}", ord_status, ord_status);
-    println!();
+	println!("  Parsed: {:?} -> Display: {}", msg_type, msg_type);
+	println!("  Parsed: {:?} -> Display: {}", side, side);
+	println!("  Parsed: {:?} -> Display: {}", ord_status, ord_status);
+	println!();
 
-    // Example 2: Automatic string conversion via Display trait
-    println!("2. Automatic String Conversion:");
-    let msg_types = vec![
-        MsgType::Heartbeat,
-        MsgType::NewOrderSingle,
-        MsgType::ExecutionReport,
-        MsgType::Other("CUSTOM".to_string()),
-    ];
+	// Example 2: Automatic string conversion via Display trait
+	println!("2. Automatic String Conversion:");
+	let msg_types = vec![
+		MsgType::Heartbeat,
+		MsgType::NewOrderSingle,
+		MsgType::ExecutionReport,
+		MsgType::Other("CUSTOM".to_string()),
+	];
 
-    for msg_type in &msg_types {
-        // All of these work automatically due to Display trait
-        let as_string = msg_type.to_string();
-        let formatted = format!("{}", msg_type);
+	for msg_type in &msg_types {
+		// All of these work automatically due to Display trait
+		let as_string = msg_type.to_string();
+		let formatted = format!("{}", msg_type);
 
-        println!(
-            "  {:?} -> to_string(): '{}', format!: '{}'",
-            msg_type, as_string, formatted
-        );
-    }
-    println!();
+		println!("  {:?} -> to_string(): '{}', format!: '{}'", msg_type, as_string, formatted);
+	}
+	println!();
 
-    // Example 3: Building messages with clean syntax
-    println!("3. Clean Builder Syntax:");
-    let message = FixMessage::builder(
-        "D".parse().unwrap(), // Clean parsing
-        "TRADER".to_string(),
-        "EXCHANGE".to_string(),
-        1,
-        "20241201-09:30:00.000".to_string(),
-    )
-    .cl_ord_id("ORDER123".to_string())
-    .symbol("AAPL".to_string())
-    .side("1".parse().unwrap()) // Clean parsing
-    .ord_status("0".parse().unwrap()) // Clean parsing
-    .order_qty(100.0)
-    .price(150.25)
-    .build();
+	// Example 3: Building messages with clean syntax
+	println!("3. Clean Builder Syntax:");
+	let message = FixMessage::builder(
+		"D".parse().unwrap(), // Clean parsing
+		"TRADER".to_string(),
+		"EXCHANGE".to_string(),
+		1,
+		"20241201-09:30:00.000".to_string(),
+	)
+	.cl_ord_id("ORDER123".to_string())
+	.symbol("AAPL".to_string())
+	.side("1".parse().unwrap()) // Clean parsing
+	.ord_status("0".parse().unwrap()) // Clean parsing
+	.order_qty(100.0)
+	.price(150.25)
+	.build();
 
-    println!("  Built message type: {}", message.msg_type);
-    println!("  Built message side: {:?}", message.side);
-    println!("  Built message status: {:?}", message.ord_status);
-    println!();
+	println!("  Built message type: {}", message.msg_type);
+	println!("  Built message side: {:?}", message.side);
+	println!("  Built message status: {:?}", message.ord_status);
+	println!();
 
-    // Example 4: Format strings and interpolation
-    println!("4. Clean String Formatting:");
-    let buy_side = Side::Buy;
-    let sell_side = Side::Sell;
-    let filled_status = OrdStatus::Filled;
-    let new_status = OrdStatus::New;
+	// Example 4: Format strings and interpolation
+	println!("4. Clean String Formatting:");
+	let buy_side = Side::Buy;
+	let sell_side = Side::Sell;
+	let filled_status = OrdStatus::Filled;
+	let new_status = OrdStatus::New;
 
-    println!(
-        "  Order: {} shares {} side, status: {}",
-        100, buy_side, new_status
-    );
-    println!(
-        "  Order: {} shares {} side, status: {}",
-        50, sell_side, filled_status
-    );
+	println!("  Order: {} shares {} side, status: {}", 100, buy_side, new_status);
+	println!("  Order: {} shares {} side, status: {}", 50, sell_side, filled_status);
 
-    // Complex formatting
-    let summary = format!(
-        "Trade Summary: {} -> {} -> {}",
-        MsgType::NewOrderSingle,
-        MsgType::ExecutionReport,
-        OrdStatus::Filled
-    );
-    println!("  {}", summary);
-    println!();
+	// Complex formatting
+	let summary =
+		format!("Trade Summary: {} -> {} -> {}", MsgType::NewOrderSingle, MsgType::ExecutionReport, OrdStatus::Filled);
+	println!("  {}", summary);
+	println!();
 
-    // Example 5: Error handling with Result types
-    println!("5. Clean Error Handling:");
-    let test_values = vec!["1", "2", "invalid", ""];
+	// Example 5: Error handling with Result types
+	println!("5. Clean Error Handling:");
+	let test_values = vec!["1", "2", "invalid", ""];
 
-    for value in test_values {
-        match value.parse::<Side>() {
-            Ok(side) => println!("  '{}' -> {} ({})", value, side, format!("{:?}", side)),
-            Err(_) => println!("  '{}' -> Invalid side value", value),
-        }
-    }
-    println!();
+	for value in test_values {
+		match value.parse::<Side>() {
+			Ok(side) => println!("  '{}' -> {} ({})", value, side, format!("{:?}", side)),
+			Err(_) => println!("  '{}' -> Invalid side value", value),
+		}
+	}
+	println!();
 
-    // Example 6: Collections and iterations
-    println!("6. Working with Collections:");
-    let sides = vec![Side::Buy, Side::Sell];
-    let side_strings: Vec<String> = sides.iter().map(|s| s.to_string()).collect();
+	// Example 6: Collections and iterations
+	println!("6. Working with Collections:");
+	let sides = vec![Side::Buy, Side::Sell];
+	let side_strings: Vec<String> = sides.iter().map(|s| s.to_string()).collect();
 
-    println!("  Sides as strings: {:?}", side_strings);
+	println!("  Sides as strings: {:?}", side_strings);
 
-    let statuses = vec![
-        OrdStatus::New,
-        OrdStatus::PartiallyFilled,
-        OrdStatus::Filled,
-    ];
+	let statuses = vec![OrdStatus::New, OrdStatus::PartiallyFilled, OrdStatus::Filled];
 
-    println!(
-        "  Status progression: {}",
-        statuses
-            .iter()
-            .map(|s| format!("{}", s))
-            .collect::<Vec<_>>()
-            .join(" -> ")
-    );
-    println!();
+	println!("  Status progression: {}", statuses.iter().map(|s| format!("{}", s)).collect::<Vec<_>>().join(" -> "));
+	println!();
 
-    // Example 7: Serialization preview
-    println!("7. Message Serialization:");
-    let fix_string = message.to_fix_string();
-    let readable = fix_string.replace('\x01', " | ");
-    println!("  FIX String: {}", readable);
+	// Example 7: Serialization preview
+	println!("7. Message Serialization:");
+	let fix_string = message.to_fix_string();
+	let readable = fix_string.replace('\x01', " | ");
+	println!("  FIX String: {}", readable);
 
-    // Parse it back
-    match FixMessage::from_fix_string(&fix_string) {
-        Ok(parsed) => {
-            println!(
-                "  Parsed back - Type: {}, Side: {:?}",
-                parsed.msg_type, parsed.side
-            );
-        }
-        Err(e) => println!("  Parse error: {}", e),
-    }
+	// Parse it back
+	match FixMessage::from_fix_string(&fix_string) {
+		Ok(parsed) => {
+			println!("  Parsed back - Type: {}, Side: {:?}", parsed.msg_type, parsed.side);
+		},
+		Err(e) => println!("  Parse error: {}", e),
+	}
 }

--- a/examples/user_message_builder.rs
+++ b/examples/user_message_builder.rs
@@ -6,126 +6,120 @@
 use fix_learning::FixMessage;
 
 fn main() {
-    println!("=== Building User's Exact FIX Message ===\n");
+	println!("=== Building User's Exact FIX Message ===\n");
 
-    // Original message without SOH separators for reference
-    let original_string = "8=FIX.4.29=16335=D34=97249=TESTBUY352=20190206-16:25:10.40356=TESTSELL311=14163685067084226997921=238=10040=154=155=AAPL60=20190206-16:25:08.968207=TO6000=TEST123410=106";
+	// Original message without SOH separators for reference
+	let original_string = "8=FIX.4.29=16335=D34=97249=TESTBUY352=20190206-16:25:10.40356=TESTSELL311=14163685067084226997921=238=10040=154=155=AAPL60=20190206-16:25:08.968207=TO6000=TEST123410=106";
 
-    println!("Original FIX string (no SOH):");
-    println!("{}\n", original_string);
+	println!("Original FIX string (no SOH):");
+	println!("{}\n", original_string);
 
-    // Build the exact same message using the builder pattern with FromStr
-    let user_message = FixMessage::builder(
-        "D".parse().unwrap(),                // 35=D (NewOrderSingle) - using FromStr
-        "TESTBUY3".to_string(),              // 49=TESTBUY3 (SenderCompID)
-        "TESTSELL3".to_string(),             // 56=TESTSELL3 (TargetCompID)
-        972,                                 // 34=972 (MsgSeqNum)
-        "20190206-16:25:10.403".to_string(), // 52=20190206-16:25:10.403 (SendingTime)
-    )
-    // Standard FIX fields
-    .cl_ord_id("14163685067084226997921".to_string()) // 11=14163685067084226997921 (ClOrdID)
-    .order_qty(100.0) // 38=100 (OrderQty)
-    .ord_type("1".to_string()) // 40=1 (OrdType - Market order)
-    .side("1".parse().unwrap()) // 54=1 (Side - Buy) - using FromStr
-    .symbol("AAPL".to_string()) // 55=AAPL (Symbol)
-    // Custom fields using the field() method
-    .field(21, "2".to_string()) // 21=2 (HandlInst)
-    .field(60, "20190206-16:25:08.968".to_string()) // 60=20190206-16:25:08.968 (TransactTime)
-    .field(207, "TO".to_string()) // 207=TO (SecurityExchange)
-    .field(6000, "TEST1234".to_string()) // 6000=TEST1234 (Custom field)
-    .build();
+	// Build the exact same message using the builder pattern with FromStr
+	let user_message = FixMessage::builder(
+		"D".parse().unwrap(),                // 35=D (NewOrderSingle) - using FromStr
+		"TESTBUY3".to_string(),              // 49=TESTBUY3 (SenderCompID)
+		"TESTSELL3".to_string(),             // 56=TESTSELL3 (TargetCompID)
+		972,                                 // 34=972 (MsgSeqNum)
+		"20190206-16:25:10.403".to_string(), // 52=20190206-16:25:10.403 (SendingTime)
+	)
+	// Standard FIX fields
+	.cl_ord_id("14163685067084226997921".to_string()) // 11=14163685067084226997921 (ClOrdID)
+	.order_qty(100.0) // 38=100 (OrderQty)
+	.ord_type("1".to_string()) // 40=1 (OrdType - Market order)
+	.side("1".parse().unwrap()) // 54=1 (Side - Buy) - using FromStr
+	.symbol("AAPL".to_string()) // 55=AAPL (Symbol)
+	// Custom fields using the field() method
+	.field(21, "2".to_string()) // 21=2 (HandlInst)
+	.field(60, "20190206-16:25:08.968".to_string()) // 60=20190206-16:25:08.968 (TransactTime)
+	.field(207, "TO".to_string()) // 207=TO (SecurityExchange)
+	.field(6000, "TEST1234".to_string()) // 6000=TEST1234 (Custom field)
+	.build();
 
-    // Serialize to FIX wire format
-    let fix_wire = user_message.to_fix_string();
-    println!("Built FIX message (wire format):");
-    println!("{}\n", fix_wire);
+	// Serialize to FIX wire format
+	let fix_wire = user_message.to_fix_string();
+	println!("Built FIX message (wire format):");
+	println!("{}\n", fix_wire);
 
-    // Show in readable format
-    let readable = fix_wire.replace('\x01', " | ");
-    println!("Built FIX message (readable):");
-    println!("{}\n", readable);
+	// Show in readable format
+	let readable = fix_wire.replace('\x01', " | ");
+	println!("Built FIX message (readable):");
+	println!("{}\n", readable);
 
-    // Demonstrate field breakdown
-    println!("=== Field Breakdown ===");
-    println!("8=FIX.4.2                    - BeginString (FIX version)");
-    println!(
-        "9={}                         - BodyLength (calculated automatically)",
-        fix_wire
-            .split('\x01')
-            .find(|s| s.starts_with("9="))
-            .unwrap_or("9=?")
-            .split('=')
-            .nth(1)
-            .unwrap_or("?")
-    );
-    println!("35=D                         - MsgType (NewOrderSingle)");
-    println!("34=972                       - MsgSeqNum");
-    println!("49=TESTBUY3                  - SenderCompID");
-    println!("52=20190206-16:25:10.403     - SendingTime");
-    println!("56=TESTSELL3                 - TargetCompID");
-    println!("11=14163685067084226997921   - ClOrdID (Client Order ID)");
-    println!("21=2                         - HandlInst (Handling Instruction)");
-    println!("38=100                       - OrderQty (Order Quantity)");
-    println!("40=1                         - OrdType (Market Order)");
-    println!("54=1                         - Side (Buy)");
-    println!("55=AAPL                      - Symbol");
-    println!("60=20190206-16:25:08.968     - TransactTime");
-    println!("207=TO                       - SecurityExchange");
-    println!("6000=TEST1234                - Custom Field");
-    println!(
-        "10={}                        - CheckSum (calculated automatically)",
-        fix_wire.split('\x01').last().unwrap_or("10=?")
-    );
+	// Demonstrate field breakdown
+	println!("=== Field Breakdown ===");
+	println!("8=FIX.4.2                    - BeginString (FIX version)");
+	println!(
+		"9={}                         - BodyLength (calculated automatically)",
+		fix_wire.split('\x01').find(|s| s.starts_with("9=")).unwrap_or("9=?").split('=').nth(1).unwrap_or("?")
+	);
+	println!("35=D                         - MsgType (NewOrderSingle)");
+	println!("34=972                       - MsgSeqNum");
+	println!("49=TESTBUY3                  - SenderCompID");
+	println!("52=20190206-16:25:10.403     - SendingTime");
+	println!("56=TESTSELL3                 - TargetCompID");
+	println!("11=14163685067084226997921   - ClOrdID (Client Order ID)");
+	println!("21=2                         - HandlInst (Handling Instruction)");
+	println!("38=100                       - OrderQty (Order Quantity)");
+	println!("40=1                         - OrdType (Market Order)");
+	println!("54=1                         - Side (Buy)");
+	println!("55=AAPL                      - Symbol");
+	println!("60=20190206-16:25:08.968     - TransactTime");
+	println!("207=TO                       - SecurityExchange");
+	println!("6000=TEST1234                - Custom Field");
+	println!(
+		"10={}                        - CheckSum (calculated automatically)",
+		fix_wire.split('\x01').last().unwrap_or("10=?")
+	);
 
-    // Parse it back to verify
-    println!("\n=== Verification (Parse Back) ===");
-    match FixMessage::from_fix_string(&fix_wire) {
-        Ok(parsed) => {
-            println!("✓ Message parsed successfully!");
-            println!("  Message Type: {:?}", parsed.msg_type);
-            println!("  Sender: {}", parsed.sender_comp_id);
-            println!("  Target: {}", parsed.target_comp_id);
-            println!("  Seq Number: {}", parsed.msg_seq_num);
-            println!("  Client Order ID: {:?}", parsed.cl_ord_id);
-            println!("  Symbol: {:?}", parsed.symbol);
-            println!("  Side: {:?}", parsed.side);
-            println!("  Quantity: {:?}", parsed.order_qty);
-            println!("  Order Type: {:?}", parsed.ord_type);
-            println!("  HandlInst (Tag 21): {:?}", parsed.get_field(21));
-            println!("  TransactTime (Tag 60): {:?}", parsed.get_field(60));
-            println!("  SecurityExchange (Tag 207): {:?}", parsed.get_field(207));
-            println!("  Custom Field (Tag 6000): {:?}", parsed.get_field(6000));
-        }
-        Err(e) => {
-            println!("✗ Parse error: {}", e);
-        }
-    }
+	// Parse it back to verify
+	println!("\n=== Verification (Parse Back) ===");
+	match FixMessage::from_fix_string(&fix_wire) {
+		Ok(parsed) => {
+			println!("✓ Message parsed successfully!");
+			println!("  Message Type: {:?}", parsed.msg_type);
+			println!("  Sender: {}", parsed.sender_comp_id);
+			println!("  Target: {}", parsed.target_comp_id);
+			println!("  Seq Number: {}", parsed.msg_seq_num);
+			println!("  Client Order ID: {:?}", parsed.cl_ord_id);
+			println!("  Symbol: {:?}", parsed.symbol);
+			println!("  Side: {:?}", parsed.side);
+			println!("  Quantity: {:?}", parsed.order_qty);
+			println!("  Order Type: {:?}", parsed.ord_type);
+			println!("  HandlInst (Tag 21): {:?}", parsed.get_field(21));
+			println!("  TransactTime (Tag 60): {:?}", parsed.get_field(60));
+			println!("  SecurityExchange (Tag 207): {:?}", parsed.get_field(207));
+			println!("  Custom Field (Tag 6000): {:?}", parsed.get_field(6000));
+		},
+		Err(e) => {
+			println!("✗ Parse error: {}", e);
+		},
+	}
 
-    println!("let msg = FixMessage::builder(\"D\".parse().unwrap(), ...)  // NewOrderSingle");
-    println!("  .cl_ord_id(\"ORDER123\".to_string())");
-    println!("  .symbol(\"AAPL\".to_string())");
-    println!("  .side(\"1\".parse().unwrap())  // Buy");
-    println!("  .build();");
-    println!();
-    println!("// Traditional usage");
-    println!("let msg = FixMessage::builder(MsgType::NewOrderSingle, ...)");
-    println!("  .side(Side::Buy)");
-    println!("  .build();");
-    println!();
-    println!("// With custom fields");
-    println!("let msg = FixMessage::builder(...)");
-    println!("  .field(207, \"NASDAQ\".to_string())  // SecurityExchange");
-    println!("  .field(6000, \"CUSTOM\".to_string())  // Custom tag");
-    println!("  .build();");
-    println!();
-    println!("// Clean enum conversions");
-    println!("let msg_type: MsgType = \"D\".parse().unwrap();");
-    println!("let side: Side = \"1\".parse().unwrap();");
-    println!("println!(\"MsgType: {{}}\", msg_type);  // Uses Display trait");
-    println!();
-    println!("// Serialize to FIX wire format");
-    println!("let fix_string = msg.to_fix_string();");
-    println!();
-    println!("// Parse from FIX wire format");
-    println!("let parsed = FixMessage::from_fix_string(&fix_string)?;");
+	println!("let msg = FixMessage::builder(\"D\".parse().unwrap(), ...)  // NewOrderSingle");
+	println!("  .cl_ord_id(\"ORDER123\".to_string())");
+	println!("  .symbol(\"AAPL\".to_string())");
+	println!("  .side(\"1\".parse().unwrap())  // Buy");
+	println!("  .build();");
+	println!();
+	println!("// Traditional usage");
+	println!("let msg = FixMessage::builder(MsgType::NewOrderSingle, ...)");
+	println!("  .side(Side::Buy)");
+	println!("  .build();");
+	println!();
+	println!("// With custom fields");
+	println!("let msg = FixMessage::builder(...)");
+	println!("  .field(207, \"NASDAQ\".to_string())  // SecurityExchange");
+	println!("  .field(6000, \"CUSTOM\".to_string())  // Custom tag");
+	println!("  .build();");
+	println!();
+	println!("// Clean enum conversions");
+	println!("let msg_type: MsgType = \"D\".parse().unwrap();");
+	println!("let side: Side = \"1\".parse().unwrap();");
+	println!("println!(\"MsgType: {{}}\", msg_type);  // Uses Display trait");
+	println!();
+	println!("// Serialize to FIX wire format");
+	println!("let fix_string = msg.to_fix_string();");
+	println!();
+	println!("// Parse from FIX wire format");
+	println!("let parsed = FixMessage::from_fix_string(&fix_string)?;");
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.89.0"
+components = ["rustfmt", "clippy", "rust-analyzer"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,19 @@
+# Basic
+hard_tabs = true
+max_width = 120
+use_small_heuristics = "Max"
+# Imports
+imports_granularity = "Crate"
+reorder_imports = true
+# Consistency
+newline_style = "Unix"
+# Misc
+spaces_around_ranges = false
+binop_separator = "Back"
+reorder_impl_items = true
+match_arm_leading_pipes = "Preserve"
+match_arm_blocks = false
+match_block_trailing_comma = true
+trailing_semicolon = false
+use_field_init_shorthand = true
+edition = "2024"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,51 +5,50 @@
 
 pub mod macros;
 
-use std::collections::HashMap;
-use std::str::FromStr;
+use std::{collections::HashMap, str::FromStr};
 
 // FIX 4.2 Message Types
 fix_enum!(Loose MsgType {
-    Heartbeat => "0",
-    TestRequest => "1",
-    ResendRequest => "2",
-    Reject => "3",
-    SequenceReset => "4",
-    Logout => "5",
-    ExecutionReport => "8",
-    OrderCancelReject => "9",
-    NewOrderSingle => "D",
-    OrderCancelRequest => "F",
-    OrderCancelReplaceRequest => "G",
-    OrderStatusRequest => "H",
-    MarketDataRequest => "V",
-    MarketDataSnapshot => "W",
-    MarketDataIncrementalRefresh => "X",
-    SecurityDefinitionRequest => "c",
-    SecurityDefinition => "d",
+	Heartbeat => "0",
+	TestRequest => "1",
+	ResendRequest => "2",
+	Reject => "3",
+	SequenceReset => "4",
+	Logout => "5",
+	ExecutionReport => "8",
+	OrderCancelReject => "9",
+	NewOrderSingle => "D",
+	OrderCancelRequest => "F",
+	OrderCancelReplaceRequest => "G",
+	OrderStatusRequest => "H",
+	MarketDataRequest => "V",
+	MarketDataSnapshot => "W",
+	MarketDataIncrementalRefresh => "X",
+	SecurityDefinitionRequest => "c",
+	SecurityDefinition => "d",
 });
 
 fix_enum!(Strict Side {
-    Buy  => "1",
-    Sell => "2",
+	Buy  => "1",
+	Sell => "2",
 });
 
 fix_enum!(Strict OrdStatus {
-    New                => "0",
-    PartiallyFilled    => "1",
-    Filled             => "2",
-    DoneForDay         => "3",
-    Canceled           => "4",
-    Replaced           => "5",
-    PendingCancel      => "6",
-    Stopped            => "7",
-    Rejected           => "8",
-    Suspended          => "9",
-    PendingNew         => "A",
-    Calculated         => "B",
-    Expired            => "C",
-    AcceptedForBidding => "D",
-    PendingReplace     => "E",
+	New                => "0",
+	PartiallyFilled    => "1",
+	Filled             => "2",
+	DoneForDay         => "3",
+	Canceled           => "4",
+	Replaced           => "5",
+	PendingCancel      => "6",
+	Stopped            => "7",
+	Rejected           => "8",
+	Suspended          => "9",
+	PendingNew         => "A",
+	Calculated         => "B",
+	Expired            => "C",
+	AcceptedForBidding => "D",
+	PendingReplace     => "E",
 });
 
 const SOH: &str = &"\x01"; // SOH character
@@ -57,511 +56,494 @@ const SOH: &str = &"\x01"; // SOH character
 // Main FIX 4.2 Message struct
 #[derive(Debug, Clone, PartialEq)]
 pub struct FixMessage {
-    // Standard Header Fields
-    pub begin_string: String,   // Tag 8 - Always "FIX.4.2"
-    pub body_length: u32,       // Tag 9 - Length of message body
-    pub msg_type: MsgType,      // Tag 35 - Message type
-    pub sender_comp_id: String, // Tag 49 - Sender's company ID
-    pub target_comp_id: String, // Tag 56 - Target's company ID
-    pub msg_seq_num: u32,       // Tag 34 - Message sequence number
-    pub sending_time: String,   // Tag 52 - Time of message transmission
+	// Standard Header Fields
+	pub begin_string: String,   // Tag 8 - Always "FIX.4.2"
+	pub body_length: u32,       // Tag 9 - Length of message body
+	pub msg_type: MsgType,      // Tag 35 - Message type
+	pub sender_comp_id: String, // Tag 49 - Sender's company ID
+	pub target_comp_id: String, // Tag 56 - Target's company ID
+	pub msg_seq_num: u32,       // Tag 34 - Message sequence number
+	pub sending_time: String,   // Tag 52 - Time of message transmission
 
-    // Optional Header Fields
-    pub poss_dup_flag: Option<bool>, // Tag 43 - Possible duplicate flag
-    pub poss_resend: Option<bool>,   // Tag 97 - Possible resend flag
-    pub orig_sending_time: Option<String>, // Tag 122 - Original sending time
+	// Optional Header Fields
+	pub poss_dup_flag: Option<bool>,       // Tag 43 - Possible duplicate flag
+	pub poss_resend: Option<bool>,         // Tag 97 - Possible resend flag
+	pub orig_sending_time: Option<String>, // Tag 122 - Original sending time
 
-    // Common Body Fields (varies by message type)
-    pub cl_ord_id: Option<String>,       // Tag 11 - Client order ID
-    pub order_id: Option<String>,        // Tag 37 - Order ID
-    pub exec_id: Option<String>,         // Tag 17 - Execution ID
-    pub exec_type: Option<String>,       // Tag 150 - Execution type
-    pub ord_status: Option<OrdStatus>,   // Tag 39 - Order status
-    pub symbol: Option<String>,          // Tag 55 - Symbol
-    pub security_type: Option<String>,   // Tag 167 - Security type
-    pub side: Option<Side>,              // Tag 54 - Side
-    pub order_qty: Option<f64>,          // Tag 38 - Order quantity
-    pub ord_type: Option<String>,        // Tag 40 - Order type
-    pub price: Option<f64>,              // Tag 44 - Price
-    pub last_qty: Option<f64>,           // Tag 32 - Last quantity
-    pub last_px: Option<f64>,            // Tag 31 - Last price
-    pub leaves_qty: Option<f64>,         // Tag 151 - Leaves quantity
-    pub cum_qty: Option<f64>,            // Tag 14 - Cumulative quantity
-    pub avg_px: Option<f64>,             // Tag 6 - Average price
-    pub text: Option<String>,            // Tag 58 - Free format text
-    pub time_in_force: Option<String>,   // Tag 59 - Time in force
-    pub exec_inst: Option<String>,       // Tag 18 - Execution instructions
-    pub handl_inst: Option<String>,      // Tag 21 - Handling instructions
-    pub exec_ref_id: Option<String>,     // Tag 19 - Execution reference ID
-    pub exec_trans_type: Option<String>, // Tag 20 - Execution transaction type
+	// Common Body Fields (varies by message type)
+	pub cl_ord_id: Option<String>,       // Tag 11 - Client order ID
+	pub order_id: Option<String>,        // Tag 37 - Order ID
+	pub exec_id: Option<String>,         // Tag 17 - Execution ID
+	pub exec_type: Option<String>,       // Tag 150 - Execution type
+	pub ord_status: Option<OrdStatus>,   // Tag 39 - Order status
+	pub symbol: Option<String>,          // Tag 55 - Symbol
+	pub security_type: Option<String>,   // Tag 167 - Security type
+	pub side: Option<Side>,              // Tag 54 - Side
+	pub order_qty: Option<f64>,          // Tag 38 - Order quantity
+	pub ord_type: Option<String>,        // Tag 40 - Order type
+	pub price: Option<f64>,              // Tag 44 - Price
+	pub last_qty: Option<f64>,           // Tag 32 - Last quantity
+	pub last_px: Option<f64>,            // Tag 31 - Last price
+	pub leaves_qty: Option<f64>,         // Tag 151 - Leaves quantity
+	pub cum_qty: Option<f64>,            // Tag 14 - Cumulative quantity
+	pub avg_px: Option<f64>,             // Tag 6 - Average price
+	pub text: Option<String>,            // Tag 58 - Free format text
+	pub time_in_force: Option<String>,   // Tag 59 - Time in force
+	pub exec_inst: Option<String>,       // Tag 18 - Execution instructions
+	pub handl_inst: Option<String>,      // Tag 21 - Handling instructions
+	pub exec_ref_id: Option<String>,     // Tag 19 - Execution reference ID
+	pub exec_trans_type: Option<String>, // Tag 20 - Execution transaction type
 
-    // Additional fields as key-value pairs for extensibility
-    pub additional_fields: HashMap<u32, String>,
+	// Additional fields as key-value pairs for extensibility
+	pub additional_fields: HashMap<u32, String>,
 
-    // Trailer
-    pub checksum: String, // Tag 10 - Checksum
+	// Trailer
+	pub checksum: String, // Tag 10 - Checksum
 }
 
 impl FixMessage {
-    // Create a new FIX message with required fields
-    pub fn new(
-        msg_type: MsgType,
-        sender_comp_id: String,
-        target_comp_id: String,
-        msg_seq_num: u32,
-        sending_time: String,
-    ) -> Self {
-        FixMessage {
-            begin_string: "FIX.4.2".to_string(),
-            body_length: 0, // Will be calculated when serializing
-            msg_type,
-            sender_comp_id,
-            target_comp_id,
-            msg_seq_num,
-            sending_time,
-            poss_dup_flag: None,
-            poss_resend: None,
-            orig_sending_time: None,
-            cl_ord_id: None,
-            order_id: None,
-            exec_id: None,
-            exec_type: None,
-            ord_status: None,
-            symbol: None,
-            security_type: None,
-            side: None,
-            order_qty: None,
-            ord_type: None,
-            price: None,
-            last_qty: None,
-            last_px: None,
-            leaves_qty: None,
-            cum_qty: None,
-            avg_px: None,
-            text: None,
-            time_in_force: None,
-            exec_inst: None,
-            handl_inst: None,
-            exec_ref_id: None,
-            exec_trans_type: None,
-            additional_fields: HashMap::new(),
-            checksum: "000".to_string(), // Will be calculated when serializing
-        }
-    }
+	// Create a new FIX message with required fields
+	pub fn new(
+		msg_type: MsgType,
+		sender_comp_id: String,
+		target_comp_id: String,
+		msg_seq_num: u32,
+		sending_time: String,
+	) -> Self {
+		FixMessage {
+			begin_string: "FIX.4.2".to_string(),
+			body_length: 0, // Will be calculated when serializing
+			msg_type,
+			sender_comp_id,
+			target_comp_id,
+			msg_seq_num,
+			sending_time,
+			poss_dup_flag: None,
+			poss_resend: None,
+			orig_sending_time: None,
+			cl_ord_id: None,
+			order_id: None,
+			exec_id: None,
+			exec_type: None,
+			ord_status: None,
+			symbol: None,
+			security_type: None,
+			side: None,
+			order_qty: None,
+			ord_type: None,
+			price: None,
+			last_qty: None,
+			last_px: None,
+			leaves_qty: None,
+			cum_qty: None,
+			avg_px: None,
+			text: None,
+			time_in_force: None,
+			exec_inst: None,
+			handl_inst: None,
+			exec_ref_id: None,
+			exec_trans_type: None,
+			additional_fields: HashMap::new(),
+			checksum: "000".to_string(), // Will be calculated when serializing
+		}
+	}
 
-    // Set a custom field
-    pub fn set_field(&mut self, tag: u32, value: String) {
-        self.additional_fields.insert(tag, value);
-    }
+	// Set a custom field
+	pub fn set_field(&mut self, tag: u32, value: String) {
+		self.additional_fields.insert(tag, value);
+	}
 
-    // Get a custom field
-    pub fn get_field(&self, tag: u32) -> Option<&String> {
-        self.additional_fields.get(&tag)
-    }
+	// Get a custom field
+	pub fn get_field(&self, tag: u32) -> Option<&String> {
+		self.additional_fields.get(&tag)
+	}
 
-    // Check if message is valid (basic validation)
-    pub fn is_valid(&self) -> bool {
-        !self.begin_string.is_empty()
-            && !self.sender_comp_id.is_empty()
-            && !self.target_comp_id.is_empty()
-            && !self.sending_time.is_empty()
-    }
+	// Check if message is valid (basic validation)
+	pub fn is_valid(&self) -> bool {
+		!self.begin_string.is_empty() &&
+			!self.sender_comp_id.is_empty() &&
+			!self.target_comp_id.is_empty() &&
+			!self.sending_time.is_empty()
+	}
 }
 
 impl Default for FixMessage {
-    fn default() -> Self {
-        FixMessage::new(
-            MsgType::Heartbeat,
-            "SENDER".to_string(),
-            "TARGET".to_string(),
-            1,
-            "20240101-00:00:00.000".to_string(),
-        )
-    }
+	fn default() -> Self {
+		FixMessage::new(
+			MsgType::Heartbeat,
+			"SENDER".to_string(),
+			"TARGET".to_string(),
+			1,
+			"20240101-00:00:00.000".to_string(),
+		)
+	}
 }
 
 // Builder pattern for creating FIX messages
 #[derive(Debug)]
 pub struct FixMessageBuilder {
-    message: FixMessage,
+	message: FixMessage,
 }
 
 impl FixMessageBuilder {
-    /// Create a new builder with required fields
-    pub fn new(
-        msg_type: MsgType,
-        sender_comp_id: String,
-        target_comp_id: String,
-        msg_seq_num: u32,
-        sending_time: String,
-    ) -> Self {
-        Self {
-            message: FixMessage::new(
-                msg_type,
-                sender_comp_id,
-                target_comp_id,
-                msg_seq_num,
-                sending_time,
-            ),
-        }
-    }
+	/// Create a new builder with required fields
+	pub fn new(
+		msg_type: MsgType,
+		sender_comp_id: String,
+		target_comp_id: String,
+		msg_seq_num: u32,
+		sending_time: String,
+	) -> Self {
+		Self { message: FixMessage::new(msg_type, sender_comp_id, target_comp_id, msg_seq_num, sending_time) }
+	}
 
-    /// Create a builder from an existing message
-    pub fn from_message(message: FixMessage) -> Self {
-        Self { message }
-    }
+	/// Create a builder from an existing message
+	pub fn from_message(message: FixMessage) -> Self {
+		Self { message }
+	}
 
-    // Header field setters
-    pub fn body_length(mut self, body_length: u32) -> Self {
-        self.message.body_length = body_length;
-        self
-    }
+	// Header field setters
+	pub fn body_length(mut self, body_length: u32) -> Self {
+		self.message.body_length = body_length;
+		self
+	}
 
-    pub fn poss_dup_flag(mut self, flag: bool) -> Self {
-        self.message.poss_dup_flag = Some(flag);
-        self
-    }
+	pub fn poss_dup_flag(mut self, flag: bool) -> Self {
+		self.message.poss_dup_flag = Some(flag);
+		self
+	}
 
-    pub fn poss_resend(mut self, flag: bool) -> Self {
-        self.message.poss_resend = Some(flag);
-        self
-    }
+	pub fn poss_resend(mut self, flag: bool) -> Self {
+		self.message.poss_resend = Some(flag);
+		self
+	}
 
-    pub fn orig_sending_time(mut self, time: String) -> Self {
-        self.message.orig_sending_time = Some(time);
-        self
-    }
+	pub fn orig_sending_time(mut self, time: String) -> Self {
+		self.message.orig_sending_time = Some(time);
+		self
+	}
 
-    // Body field setters
-    pub fn cl_ord_id(mut self, cl_ord_id: String) -> Self {
-        self.message.cl_ord_id = Some(cl_ord_id);
-        self
-    }
+	// Body field setters
+	pub fn cl_ord_id(mut self, cl_ord_id: String) -> Self {
+		self.message.cl_ord_id = Some(cl_ord_id);
+		self
+	}
 
-    pub fn order_id(mut self, order_id: String) -> Self {
-        self.message.order_id = Some(order_id);
-        self
-    }
+	pub fn order_id(mut self, order_id: String) -> Self {
+		self.message.order_id = Some(order_id);
+		self
+	}
 
-    pub fn exec_id(mut self, exec_id: String) -> Self {
-        self.message.exec_id = Some(exec_id);
-        self
-    }
+	pub fn exec_id(mut self, exec_id: String) -> Self {
+		self.message.exec_id = Some(exec_id);
+		self
+	}
 
-    pub fn exec_type(mut self, exec_type: String) -> Self {
-        self.message.exec_type = Some(exec_type);
-        self
-    }
+	pub fn exec_type(mut self, exec_type: String) -> Self {
+		self.message.exec_type = Some(exec_type);
+		self
+	}
 
-    pub fn ord_status(mut self, ord_status: OrdStatus) -> Self {
-        self.message.ord_status = Some(ord_status);
-        self
-    }
+	pub fn ord_status(mut self, ord_status: OrdStatus) -> Self {
+		self.message.ord_status = Some(ord_status);
+		self
+	}
 
-    pub fn symbol(mut self, symbol: String) -> Self {
-        self.message.symbol = Some(symbol);
-        self
-    }
+	pub fn symbol(mut self, symbol: String) -> Self {
+		self.message.symbol = Some(symbol);
+		self
+	}
 
-    pub fn security_type(mut self, security_type: String) -> Self {
-        self.message.security_type = Some(security_type);
-        self
-    }
+	pub fn security_type(mut self, security_type: String) -> Self {
+		self.message.security_type = Some(security_type);
+		self
+	}
 
-    pub fn side(mut self, side: Side) -> Self {
-        self.message.side = Some(side);
-        self
-    }
+	pub fn side(mut self, side: Side) -> Self {
+		self.message.side = Some(side);
+		self
+	}
 
-    pub fn order_qty(mut self, qty: f64) -> Self {
-        self.message.order_qty = Some(qty);
-        self
-    }
+	pub fn order_qty(mut self, qty: f64) -> Self {
+		self.message.order_qty = Some(qty);
+		self
+	}
 
-    pub fn ord_type(mut self, ord_type: String) -> Self {
-        self.message.ord_type = Some(ord_type);
-        self
-    }
+	pub fn ord_type(mut self, ord_type: String) -> Self {
+		self.message.ord_type = Some(ord_type);
+		self
+	}
 
-    pub fn price(mut self, price: f64) -> Self {
-        self.message.price = Some(price);
-        self
-    }
+	pub fn price(mut self, price: f64) -> Self {
+		self.message.price = Some(price);
+		self
+	}
 
-    pub fn last_qty(mut self, qty: f64) -> Self {
-        self.message.last_qty = Some(qty);
-        self
-    }
+	pub fn last_qty(mut self, qty: f64) -> Self {
+		self.message.last_qty = Some(qty);
+		self
+	}
 
-    pub fn last_px(mut self, price: f64) -> Self {
-        self.message.last_px = Some(price);
-        self
-    }
+	pub fn last_px(mut self, price: f64) -> Self {
+		self.message.last_px = Some(price);
+		self
+	}
 
-    pub fn leaves_qty(mut self, qty: f64) -> Self {
-        self.message.leaves_qty = Some(qty);
-        self
-    }
+	pub fn leaves_qty(mut self, qty: f64) -> Self {
+		self.message.leaves_qty = Some(qty);
+		self
+	}
 
-    pub fn cum_qty(mut self, qty: f64) -> Self {
-        self.message.cum_qty = Some(qty);
-        self
-    }
+	pub fn cum_qty(mut self, qty: f64) -> Self {
+		self.message.cum_qty = Some(qty);
+		self
+	}
 
-    pub fn avg_px(mut self, price: f64) -> Self {
-        self.message.avg_px = Some(price);
-        self
-    }
+	pub fn avg_px(mut self, price: f64) -> Self {
+		self.message.avg_px = Some(price);
+		self
+	}
 
-    pub fn text(mut self, text: String) -> Self {
-        self.message.text = Some(text);
-        self
-    }
+	pub fn text(mut self, text: String) -> Self {
+		self.message.text = Some(text);
+		self
+	}
 
-    pub fn time_in_force(mut self, tif: String) -> Self {
-        self.message.time_in_force = Some(tif);
-        self
-    }
+	pub fn time_in_force(mut self, tif: String) -> Self {
+		self.message.time_in_force = Some(tif);
+		self
+	}
 
-    pub fn exec_inst(mut self, exec_inst: String) -> Self {
-        self.message.exec_inst = Some(exec_inst);
-        self
-    }
+	pub fn exec_inst(mut self, exec_inst: String) -> Self {
+		self.message.exec_inst = Some(exec_inst);
+		self
+	}
 
-    pub fn handl_inst(mut self, handl_inst: String) -> Self {
-        self.message.handl_inst = Some(handl_inst);
-        self
-    }
+	pub fn handl_inst(mut self, handl_inst: String) -> Self {
+		self.message.handl_inst = Some(handl_inst);
+		self
+	}
 
-    pub fn exec_ref_id(mut self, exec_ref_id: String) -> Self {
-        self.message.exec_ref_id = Some(exec_ref_id);
-        self
-    }
+	pub fn exec_ref_id(mut self, exec_ref_id: String) -> Self {
+		self.message.exec_ref_id = Some(exec_ref_id);
+		self
+	}
 
-    pub fn exec_trans_type(mut self, exec_trans_type: String) -> Self {
-        self.message.exec_trans_type = Some(exec_trans_type);
-        self
-    }
+	pub fn exec_trans_type(mut self, exec_trans_type: String) -> Self {
+		self.message.exec_trans_type = Some(exec_trans_type);
+		self
+	}
 
-    // Custom field setter
-    pub fn field(mut self, tag: u32, value: String) -> Self {
-        self.message.set_field(tag, value);
-        self
-    }
+	// Custom field setter
+	pub fn field(mut self, tag: u32, value: String) -> Self {
+		self.message.set_field(tag, value);
+		self
+	}
 
-    // Checksum setter
-    pub fn checksum(mut self, checksum: String) -> Self {
-        self.message.checksum = checksum;
-        self
-    }
+	// Checksum setter
+	pub fn checksum(mut self, checksum: String) -> Self {
+		self.message.checksum = checksum;
+		self
+	}
 
-    /// Build the final message
-    pub fn build(self) -> FixMessage {
-        self.message
-    }
+	/// Build the final message
+	pub fn build(self) -> FixMessage {
+		self.message
+	}
 }
 
 impl FixMessage {
-    /// Create a new builder for this message type
-    pub fn builder(
-        msg_type: MsgType,
-        sender_comp_id: String,
-        target_comp_id: String,
-        msg_seq_num: u32,
-        sending_time: String,
-    ) -> FixMessageBuilder {
-        FixMessageBuilder::new(
-            msg_type,
-            sender_comp_id,
-            target_comp_id,
-            msg_seq_num,
-            sending_time,
-        )
-    }
+	/// Create a new builder for this message type
+	pub fn builder(
+		msg_type: MsgType,
+		sender_comp_id: String,
+		target_comp_id: String,
+		msg_seq_num: u32,
+		sending_time: String,
+	) -> FixMessageBuilder {
+		FixMessageBuilder::new(msg_type, sender_comp_id, target_comp_id, msg_seq_num, sending_time)
+	}
 
-    /// Serialize the message to FIX wire format
-    pub fn to_fix_string(&self) -> String {
-        let mut fields = Vec::new();
+	/// Serialize the message to FIX wire format
+	pub fn to_fix_string(&self) -> String {
+		let mut fields = Vec::new();
 
-        // Standard Header Fields (in order)
-        fields.push(format!("8={}", self.begin_string));
+		// Standard Header Fields (in order)
+		fields.push(format!("8={}", self.begin_string));
 
-        // We'll calculate body length after building the body
-        let mut body_fields = Vec::new();
+		// We'll calculate body length after building the body
+		let mut body_fields = Vec::new();
 
-        // Message type
-        body_fields.push(format!("35={}", self.msg_type));
+		// Message type
+		body_fields.push(format!("35={}", self.msg_type));
 
-        // Message sequence number
-        body_fields.push(format!("34={}", self.msg_seq_num));
+		// Message sequence number
+		body_fields.push(format!("34={}", self.msg_seq_num));
 
-        // Sender and target
-        body_fields.push(format!("49={}", self.sender_comp_id));
-        body_fields.push(format!("52={}", self.sending_time));
-        body_fields.push(format!("56={}", self.target_comp_id));
+		// Sender and target
+		body_fields.push(format!("49={}", self.sender_comp_id));
+		body_fields.push(format!("52={}", self.sending_time));
+		body_fields.push(format!("56={}", self.target_comp_id));
 
-        // Optional header fields
-        if let Some(flag) = self.poss_dup_flag {
-            body_fields.push(format!("43={}", if flag { "Y" } else { "N" }));
-        }
-        if let Some(flag) = self.poss_resend {
-            body_fields.push(format!("97={}", if flag { "Y" } else { "N" }));
-        }
-        if let Some(ref time) = self.orig_sending_time {
-            body_fields.push(format!("122={}", time));
-        }
+		// Optional header fields
+		if let Some(flag) = self.poss_dup_flag {
+			body_fields.push(format!("43={}", if flag { "Y" } else { "N" }));
+		}
+		if let Some(flag) = self.poss_resend {
+			body_fields.push(format!("97={}", if flag { "Y" } else { "N" }));
+		}
+		if let Some(ref time) = self.orig_sending_time {
+			body_fields.push(format!("122={}", time));
+		}
 
-        // Body fields (in tag order for consistency)
-        if let Some(ref cl_ord_id) = self.cl_ord_id {
-            body_fields.push(format!("11={}", cl_ord_id));
-        }
-        if let Some(ref exec_ref_id) = self.exec_ref_id {
-            body_fields.push(format!("19={}", exec_ref_id));
-        }
-        if let Some(ref exec_trans_type) = self.exec_trans_type {
-            body_fields.push(format!("20={}", exec_trans_type));
-        }
-        if let Some(ref handl_inst) = self.handl_inst {
-            body_fields.push(format!("21={}", handl_inst));
-        }
-        if let Some(ref last_px) = self.last_px {
-            body_fields.push(format!("31={}", last_px));
-        }
-        if let Some(ref last_qty) = self.last_qty {
-            body_fields.push(format!("32={}", last_qty));
-        }
-        if let Some(ref order_id) = self.order_id {
-            body_fields.push(format!("37={}", order_id));
-        }
-        if let Some(ref order_qty) = self.order_qty {
-            body_fields.push(format!("38={}", order_qty));
-        }
-        if let Some(ref ord_status) = self.ord_status {
-            body_fields.push(format!("39={}", ord_status));
-        }
-        if let Some(ref ord_type) = self.ord_type {
-            body_fields.push(format!("40={}", ord_type));
-        }
-        if let Some(ref price) = self.price {
-            body_fields.push(format!("44={}", price));
-        }
-        if let Some(ref side) = self.side {
-            body_fields.push(format!("54={}", side));
-        }
-        if let Some(ref symbol) = self.symbol {
-            body_fields.push(format!("55={}", symbol));
-        }
-        if let Some(ref text) = self.text {
-            body_fields.push(format!("58={}", text));
-        }
-        if let Some(ref time_in_force) = self.time_in_force {
-            body_fields.push(format!("59={}", time_in_force));
-        }
-        if let Some(ref avg_px) = self.avg_px {
-            body_fields.push(format!("6={}", avg_px));
-        }
-        if let Some(ref cum_qty) = self.cum_qty {
-            body_fields.push(format!("14={}", cum_qty));
-        }
-        if let Some(ref exec_id) = self.exec_id {
-            body_fields.push(format!("17={}", exec_id));
-        }
-        if let Some(ref exec_inst) = self.exec_inst {
-            body_fields.push(format!("18={}", exec_inst));
-        }
-        if let Some(ref exec_type) = self.exec_type {
-            body_fields.push(format!("150={}", exec_type));
-        }
-        if let Some(ref leaves_qty) = self.leaves_qty {
-            body_fields.push(format!("151={}", leaves_qty));
-        }
-        if let Some(ref security_type) = self.security_type {
-            body_fields.push(format!("167={}", security_type));
-        }
+		// Body fields (in tag order for consistency)
+		if let Some(ref cl_ord_id) = self.cl_ord_id {
+			body_fields.push(format!("11={}", cl_ord_id));
+		}
+		if let Some(ref exec_ref_id) = self.exec_ref_id {
+			body_fields.push(format!("19={}", exec_ref_id));
+		}
+		if let Some(ref exec_trans_type) = self.exec_trans_type {
+			body_fields.push(format!("20={}", exec_trans_type));
+		}
+		if let Some(ref handl_inst) = self.handl_inst {
+			body_fields.push(format!("21={}", handl_inst));
+		}
+		if let Some(ref last_px) = self.last_px {
+			body_fields.push(format!("31={}", last_px));
+		}
+		if let Some(ref last_qty) = self.last_qty {
+			body_fields.push(format!("32={}", last_qty));
+		}
+		if let Some(ref order_id) = self.order_id {
+			body_fields.push(format!("37={}", order_id));
+		}
+		if let Some(ref order_qty) = self.order_qty {
+			body_fields.push(format!("38={}", order_qty));
+		}
+		if let Some(ref ord_status) = self.ord_status {
+			body_fields.push(format!("39={}", ord_status));
+		}
+		if let Some(ref ord_type) = self.ord_type {
+			body_fields.push(format!("40={}", ord_type));
+		}
+		if let Some(ref price) = self.price {
+			body_fields.push(format!("44={}", price));
+		}
+		if let Some(ref side) = self.side {
+			body_fields.push(format!("54={}", side));
+		}
+		if let Some(ref symbol) = self.symbol {
+			body_fields.push(format!("55={}", symbol));
+		}
+		if let Some(ref text) = self.text {
+			body_fields.push(format!("58={}", text));
+		}
+		if let Some(ref time_in_force) = self.time_in_force {
+			body_fields.push(format!("59={}", time_in_force));
+		}
+		if let Some(ref avg_px) = self.avg_px {
+			body_fields.push(format!("6={}", avg_px));
+		}
+		if let Some(ref cum_qty) = self.cum_qty {
+			body_fields.push(format!("14={}", cum_qty));
+		}
+		if let Some(ref exec_id) = self.exec_id {
+			body_fields.push(format!("17={}", exec_id));
+		}
+		if let Some(ref exec_inst) = self.exec_inst {
+			body_fields.push(format!("18={}", exec_inst));
+		}
+		if let Some(ref exec_type) = self.exec_type {
+			body_fields.push(format!("150={}", exec_type));
+		}
+		if let Some(ref leaves_qty) = self.leaves_qty {
+			body_fields.push(format!("151={}", leaves_qty));
+		}
+		if let Some(ref security_type) = self.security_type {
+			body_fields.push(format!("167={}", security_type));
+		}
 
-        // Add custom fields (sorted by tag number)
-        let mut custom_fields: Vec<_> = self.additional_fields.iter().collect();
-        custom_fields.sort_by_key(|(tag, _)| *tag);
-        for (tag, value) in custom_fields {
-            body_fields.push(format!("{}={}", tag, value));
-        }
+		// Add custom fields (sorted by tag number)
+		let mut custom_fields: Vec<_> = self.additional_fields.iter().collect();
+		custom_fields.sort_by_key(|(tag, _)| *tag);
+		for (tag, value) in custom_fields {
+			body_fields.push(format!("{}={}", tag, value));
+		}
 
-        // Calculate body length
-        let body_string = body_fields.join(SOH);
-        let body_length = body_string.len();
-        fields.push(format!("9={}", body_length));
+		// Calculate body length
+		let body_string = body_fields.join(SOH);
+		let body_length = body_string.len();
+		fields.push(format!("9={}", body_length));
 
-        // Add body fields
-        fields.extend(body_fields);
+		// Add body fields
+		fields.extend(body_fields);
 
-        // Add checksum
-        let message_without_checksum = fields.join(SOH) + SOH;
-        let calculated_checksum = Self::calculate_checksum(&message_without_checksum);
-        fields.push(format!("10={:03}", calculated_checksum));
+		// Add checksum
+		let message_without_checksum = fields.join(SOH) + SOH;
+		let calculated_checksum = Self::calculate_checksum(&message_without_checksum);
+		fields.push(format!("10={:03}", calculated_checksum));
 
-        // Join all fields with SOH
-        fields.join(SOH)
-    }
+		// Join all fields with SOH
+		fields.join(SOH)
+	}
 
-    /// Calculate FIX checksum
-    fn calculate_checksum(message: &str) -> u32 {
-        message.bytes().map(|b| b as u32).sum::<u32>() % 256
-    }
+	/// Calculate FIX checksum
+	fn calculate_checksum(message: &str) -> u32 {
+		message.bytes().map(|b| b as u32).sum::<u32>() % 256
+	}
 
-    /// Parse a FIX message from wire format
-    pub fn from_fix_string(fix_string: &str) -> Result<Self, String> {
-        let fields: Vec<&str> = fix_string.split(SOH).filter(|s| !s.is_empty()).collect();
+	/// Parse a FIX message from wire format
+	pub fn from_fix_string(fix_string: &str) -> Result<Self, String> {
+		let fields: Vec<&str> = fix_string.split(SOH).filter(|s| !s.is_empty()).collect();
 
-        if fields.is_empty() {
-            return Err("Empty FIX message".to_string());
-        }
+		if fields.is_empty() {
+			return Err("Empty FIX message".to_string());
+		}
 
-        let mut message = FixMessage::default();
+		let mut message = FixMessage::default();
 
-        for field in fields {
-            if let Some((tag_str, value)) = field.split_once('=') {
-                match tag_str.parse::<u32>() {
-                    Ok(8) => message.begin_string = value.to_string(),
-                    Ok(9) => message.body_length = value.parse().unwrap_or(0),
-                    Ok(35) => {
-                        message.msg_type =
-                            MsgType::from_str(value).unwrap_or(MsgType::Other(value.to_string()))
-                    }
-                    Ok(34) => message.msg_seq_num = value.parse().unwrap_or(0),
-                    Ok(49) => message.sender_comp_id = value.to_string(),
-                    Ok(52) => message.sending_time = value.to_string(),
-                    Ok(56) => message.target_comp_id = value.to_string(),
-                    Ok(11) => message.cl_ord_id = Some(value.to_string()),
-                    Ok(37) => message.order_id = Some(value.to_string()),
-                    Ok(17) => message.exec_id = Some(value.to_string()),
-                    Ok(150) => message.exec_type = Some(value.to_string()),
-                    Ok(39) => message.ord_status = OrdStatus::from_str(value).ok(),
-                    Ok(55) => message.symbol = Some(value.to_string()),
-                    Ok(167) => message.security_type = Some(value.to_string()),
-                    Ok(54) => message.side = Side::from_str(value).ok(),
-                    Ok(38) => message.order_qty = value.parse().ok(),
-                    Ok(40) => message.ord_type = Some(value.to_string()),
-                    Ok(44) => message.price = value.parse().ok(),
-                    Ok(32) => message.last_qty = value.parse().ok(),
-                    Ok(31) => message.last_px = value.parse().ok(),
-                    Ok(151) => message.leaves_qty = value.parse().ok(),
-                    Ok(14) => message.cum_qty = value.parse().ok(),
-                    Ok(6) => message.avg_px = value.parse().ok(),
-                    Ok(58) => message.text = Some(value.to_string()),
-                    Ok(59) => message.time_in_force = Some(value.to_string()),
-                    Ok(18) => message.exec_inst = Some(value.to_string()),
-                    Ok(21) => message.handl_inst = Some(value.to_string()),
-                    Ok(19) => message.exec_ref_id = Some(value.to_string()),
-                    Ok(20) => message.exec_trans_type = Some(value.to_string()),
-                    Ok(10) => message.checksum = value.to_string(),
-                    Ok(tag) => {
-                        message.additional_fields.insert(tag, value.to_string());
-                    }
-                    Err(_) => return Err(format!("Invalid tag: {}", tag_str)),
-                }
-            }
-        }
+		for field in fields {
+			if let Some((tag_str, value)) = field.split_once('=') {
+				match tag_str.parse::<u32>() {
+					Ok(8) => message.begin_string = value.to_string(),
+					Ok(9) => message.body_length = value.parse().unwrap_or(0),
+					Ok(35) => message.msg_type = MsgType::from_str(value).unwrap_or(MsgType::Other(value.to_string())),
+					Ok(34) => message.msg_seq_num = value.parse().unwrap_or(0),
+					Ok(49) => message.sender_comp_id = value.to_string(),
+					Ok(52) => message.sending_time = value.to_string(),
+					Ok(56) => message.target_comp_id = value.to_string(),
+					Ok(11) => message.cl_ord_id = Some(value.to_string()),
+					Ok(37) => message.order_id = Some(value.to_string()),
+					Ok(17) => message.exec_id = Some(value.to_string()),
+					Ok(150) => message.exec_type = Some(value.to_string()),
+					Ok(39) => message.ord_status = OrdStatus::from_str(value).ok(),
+					Ok(55) => message.symbol = Some(value.to_string()),
+					Ok(167) => message.security_type = Some(value.to_string()),
+					Ok(54) => message.side = Side::from_str(value).ok(),
+					Ok(38) => message.order_qty = value.parse().ok(),
+					Ok(40) => message.ord_type = Some(value.to_string()),
+					Ok(44) => message.price = value.parse().ok(),
+					Ok(32) => message.last_qty = value.parse().ok(),
+					Ok(31) => message.last_px = value.parse().ok(),
+					Ok(151) => message.leaves_qty = value.parse().ok(),
+					Ok(14) => message.cum_qty = value.parse().ok(),
+					Ok(6) => message.avg_px = value.parse().ok(),
+					Ok(58) => message.text = Some(value.to_string()),
+					Ok(59) => message.time_in_force = Some(value.to_string()),
+					Ok(18) => message.exec_inst = Some(value.to_string()),
+					Ok(21) => message.handl_inst = Some(value.to_string()),
+					Ok(19) => message.exec_ref_id = Some(value.to_string()),
+					Ok(20) => message.exec_trans_type = Some(value.to_string()),
+					Ok(10) => message.checksum = value.to_string(),
+					Ok(tag) => {
+						message.additional_fields.insert(tag, value.to_string());
+					},
+					Err(_) => return Err(format!("Invalid tag: {}", tag_str)),
+				}
+			}
+		}
 
-        Ok(message)
-    }
+		Ok(message)
+	}
 }

--- a/tests/builder_tests.rs
+++ b/tests/builder_tests.rs
@@ -8,712 +8,702 @@ use std::str::FromStr;
 
 #[cfg(test)]
 mod builder_pattern_tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn test_basic_builder_creation() {
-        let message = FixMessage::builder(
-            MsgType::Heartbeat,
-            "SENDER".to_string(),
-            "TARGET".to_string(),
-            1,
-            "20241201-12:00:00.000".to_string(),
-        )
-        .build();
+	#[test]
+	fn test_basic_builder_creation() {
+		let message = FixMessage::builder(
+			MsgType::Heartbeat,
+			"SENDER".to_string(),
+			"TARGET".to_string(),
+			1,
+			"20241201-12:00:00.000".to_string(),
+		)
+		.build();
 
-        assert_eq!(message.msg_type, MsgType::Heartbeat);
-        assert_eq!(message.sender_comp_id, "SENDER");
-        assert_eq!(message.target_comp_id, "TARGET");
-        assert_eq!(message.msg_seq_num, 1);
-        assert_eq!(message.sending_time, "20241201-12:00:00.000");
-    }
+		assert_eq!(message.msg_type, MsgType::Heartbeat);
+		assert_eq!(message.sender_comp_id, "SENDER");
+		assert_eq!(message.target_comp_id, "TARGET");
+		assert_eq!(message.msg_seq_num, 1);
+		assert_eq!(message.sending_time, "20241201-12:00:00.000");
+	}
 
-    #[test]
-    fn test_builder_fluent_interface() {
-        let message = FixMessage::builder(
-            MsgType::NewOrderSingle,
-            "CLIENT".to_string(),
-            "BROKER".to_string(),
-            100,
-            "20241201-09:30:00.000".to_string(),
-        )
-        .cl_ord_id("ORDER123".to_string())
-        .symbol("AAPL".to_string())
-        .side(Side::Buy)
-        .order_qty(100.0)
-        .ord_type("2".to_string())
-        .price(150.25)
-        .time_in_force("0".to_string())
-        .build();
+	#[test]
+	fn test_builder_fluent_interface() {
+		let message = FixMessage::builder(
+			MsgType::NewOrderSingle,
+			"CLIENT".to_string(),
+			"BROKER".to_string(),
+			100,
+			"20241201-09:30:00.000".to_string(),
+		)
+		.cl_ord_id("ORDER123".to_string())
+		.symbol("AAPL".to_string())
+		.side(Side::Buy)
+		.order_qty(100.0)
+		.ord_type("2".to_string())
+		.price(150.25)
+		.time_in_force("0".to_string())
+		.build();
 
-        assert_eq!(message.cl_ord_id, Some("ORDER123".to_string()));
-        assert_eq!(message.symbol, Some("AAPL".to_string()));
-        assert_eq!(message.side, Some(Side::Buy));
-        assert_eq!(message.order_qty, Some(100.0));
-        assert_eq!(message.price, Some(150.25));
-    }
+		assert_eq!(message.cl_ord_id, Some("ORDER123".to_string()));
+		assert_eq!(message.symbol, Some("AAPL".to_string()));
+		assert_eq!(message.side, Some(Side::Buy));
+		assert_eq!(message.order_qty, Some(100.0));
+		assert_eq!(message.price, Some(150.25));
+	}
 
-    #[test]
-    fn test_builder_with_custom_fields() {
-        let message = FixMessage::builder(
-            MsgType::ExecutionReport,
-            "EXCHANGE".to_string(),
-            "CLIENT".to_string(),
-            200,
-            "20241201-10:00:00.000".to_string(),
-        )
-        .symbol("MSFT".to_string())
-        .field(207, "NASDAQ".to_string()) // SecurityExchange
-        .field(6000, "CUSTOM_DATA".to_string())
-        .field(9999, "TEST_FIELD".to_string())
-        .build();
+	#[test]
+	fn test_builder_with_custom_fields() {
+		let message = FixMessage::builder(
+			MsgType::ExecutionReport,
+			"EXCHANGE".to_string(),
+			"CLIENT".to_string(),
+			200,
+			"20241201-10:00:00.000".to_string(),
+		)
+		.symbol("MSFT".to_string())
+		.field(207, "NASDAQ".to_string()) // SecurityExchange
+		.field(6000, "CUSTOM_DATA".to_string())
+		.field(9999, "TEST_FIELD".to_string())
+		.build();
 
-        assert_eq!(message.symbol, Some("MSFT".to_string()));
-        assert_eq!(message.get_field(207), Some(&"NASDAQ".to_string()));
-        assert_eq!(message.get_field(6000), Some(&"CUSTOM_DATA".to_string()));
-        assert_eq!(message.get_field(9999), Some(&"TEST_FIELD".to_string()));
-    }
+		assert_eq!(message.symbol, Some("MSFT".to_string()));
+		assert_eq!(message.get_field(207), Some(&"NASDAQ".to_string()));
+		assert_eq!(message.get_field(6000), Some(&"CUSTOM_DATA".to_string()));
+		assert_eq!(message.get_field(9999), Some(&"TEST_FIELD".to_string()));
+	}
 
-    #[test]
-    fn test_builder_all_standard_fields() {
-        let message = FixMessage::builder(
-            MsgType::ExecutionReport,
-            "BROKER".to_string(),
-            "CLIENT".to_string(),
-            500,
-            "20241201-11:30:00.000".to_string(),
-        )
-        .cl_ord_id("CLIENT_ORDER_1".to_string())
-        .order_id("BROKER_ORDER_1".to_string())
-        .exec_id("EXEC_001".to_string())
-        .exec_type("F".to_string())
-        .ord_status(OrdStatus::Filled)
-        .symbol("TSLA".to_string())
-        .security_type("CS".to_string())
-        .side(Side::Sell)
-        .order_qty(200.0)
-        .ord_type("1".to_string())
-        .price(250.50)
-        .last_qty(200.0)
-        .last_px(250.75)
-        .leaves_qty(0.0)
-        .cum_qty(200.0)
-        .avg_px(250.75)
-        .text("FILL COMPLETE".to_string())
-        .time_in_force("0".to_string())
-        .exec_inst("O".to_string())
-        .handl_inst("1".to_string())
-        .exec_ref_id("REF_001".to_string())
-        .exec_trans_type("0".to_string())
-        .build();
+	#[test]
+	fn test_builder_all_standard_fields() {
+		let message = FixMessage::builder(
+			MsgType::ExecutionReport,
+			"BROKER".to_string(),
+			"CLIENT".to_string(),
+			500,
+			"20241201-11:30:00.000".to_string(),
+		)
+		.cl_ord_id("CLIENT_ORDER_1".to_string())
+		.order_id("BROKER_ORDER_1".to_string())
+		.exec_id("EXEC_001".to_string())
+		.exec_type("F".to_string())
+		.ord_status(OrdStatus::Filled)
+		.symbol("TSLA".to_string())
+		.security_type("CS".to_string())
+		.side(Side::Sell)
+		.order_qty(200.0)
+		.ord_type("1".to_string())
+		.price(250.50)
+		.last_qty(200.0)
+		.last_px(250.75)
+		.leaves_qty(0.0)
+		.cum_qty(200.0)
+		.avg_px(250.75)
+		.text("FILL COMPLETE".to_string())
+		.time_in_force("0".to_string())
+		.exec_inst("O".to_string())
+		.handl_inst("1".to_string())
+		.exec_ref_id("REF_001".to_string())
+		.exec_trans_type("0".to_string())
+		.build();
 
-        // Verify all fields were set correctly
-        assert_eq!(message.cl_ord_id, Some("CLIENT_ORDER_1".to_string()));
-        assert_eq!(message.order_id, Some("BROKER_ORDER_1".to_string()));
-        assert_eq!(message.exec_id, Some("EXEC_001".to_string()));
-        assert_eq!(message.exec_type, Some("F".to_string()));
-        assert_eq!(message.ord_status, Some(OrdStatus::Filled));
-        assert_eq!(message.symbol, Some("TSLA".to_string()));
-        assert_eq!(message.side, Some(Side::Sell));
-        assert_eq!(message.order_qty, Some(200.0));
-        assert_eq!(message.last_qty, Some(200.0));
-        assert_eq!(message.cum_qty, Some(200.0));
-        assert_eq!(message.text, Some("FILL COMPLETE".to_string()));
-    }
+		// Verify all fields were set correctly
+		assert_eq!(message.cl_ord_id, Some("CLIENT_ORDER_1".to_string()));
+		assert_eq!(message.order_id, Some("BROKER_ORDER_1".to_string()));
+		assert_eq!(message.exec_id, Some("EXEC_001".to_string()));
+		assert_eq!(message.exec_type, Some("F".to_string()));
+		assert_eq!(message.ord_status, Some(OrdStatus::Filled));
+		assert_eq!(message.symbol, Some("TSLA".to_string()));
+		assert_eq!(message.side, Some(Side::Sell));
+		assert_eq!(message.order_qty, Some(200.0));
+		assert_eq!(message.last_qty, Some(200.0));
+		assert_eq!(message.cum_qty, Some(200.0));
+		assert_eq!(message.text, Some("FILL COMPLETE".to_string()));
+	}
 
-    #[test]
-    fn test_builder_from_existing_message() {
-        let original = FixMessage::builder(
-            MsgType::ExecutionReport,
-            "PHLX".to_string(),
-            "PERS".to_string(),
-            1,
-            "20071123-05:30:00.000".to_string(),
-        )
-        .cl_ord_id("ATOMNOCCC9990900".to_string())
-        .symbol("MSFT".to_string())
-        .price(15.0)
-        .build();
+	#[test]
+	fn test_builder_from_existing_message() {
+		let original = FixMessage::builder(
+			MsgType::ExecutionReport,
+			"PHLX".to_string(),
+			"PERS".to_string(),
+			1,
+			"20071123-05:30:00.000".to_string(),
+		)
+		.cl_ord_id("ATOMNOCCC9990900".to_string())
+		.symbol("MSFT".to_string())
+		.price(15.0)
+		.build();
 
-        let modified = FixMessageBuilder::from_message(original.clone())
-            .symbol("GOOGL".to_string())
-            .price(2500.0)
-            .field(5000, "MODIFIED".to_string())
-            .build();
+		let modified = FixMessageBuilder::from_message(original.clone())
+			.symbol("GOOGL".to_string())
+			.price(2500.0)
+			.field(5000, "MODIFIED".to_string())
+			.build();
 
-        // Original fields should be preserved
-        assert_eq!(modified.sender_comp_id, original.sender_comp_id);
-        assert_eq!(modified.target_comp_id, original.target_comp_id);
-        assert_eq!(modified.cl_ord_id, original.cl_ord_id);
+		// Original fields should be preserved
+		assert_eq!(modified.sender_comp_id, original.sender_comp_id);
+		assert_eq!(modified.target_comp_id, original.target_comp_id);
+		assert_eq!(modified.cl_ord_id, original.cl_ord_id);
 
-        // Modified fields should be updated
-        assert_eq!(modified.symbol, Some("GOOGL".to_string()));
-        assert_eq!(modified.price, Some(2500.0));
-        assert_eq!(modified.get_field(5000), Some(&"MODIFIED".to_string()));
+		// Modified fields should be updated
+		assert_eq!(modified.symbol, Some("GOOGL".to_string()));
+		assert_eq!(modified.price, Some(2500.0));
+		assert_eq!(modified.get_field(5000), Some(&"MODIFIED".to_string()));
 
-        // Original should remain unchanged
-        assert_eq!(original.symbol, Some("MSFT".to_string()));
-        assert_eq!(original.price, Some(15.0));
-        // Verify the fields were actually modified
-        assert_ne!(original.symbol, modified.symbol);
-        assert_ne!(original.price, modified.price);
-    }
+		// Original should remain unchanged
+		assert_eq!(original.symbol, Some("MSFT".to_string()));
+		assert_eq!(original.price, Some(15.0));
+		// Verify the fields were actually modified
+		assert_ne!(original.symbol, modified.symbol);
+		assert_ne!(original.price, modified.price);
+	}
 
-    #[test]
-    fn test_builder_optional_header_fields() {
-        let message = FixMessage::builder(
-            MsgType::TestRequest,
-            "SENDER".to_string(),
-            "TARGET".to_string(),
-            10,
-            "20241201-12:00:00.000".to_string(),
-        )
-        .poss_dup_flag(true)
-        .poss_resend(false)
-        .orig_sending_time("20241201-11:59:00.000".to_string())
-        .build();
+	#[test]
+	fn test_builder_optional_header_fields() {
+		let message = FixMessage::builder(
+			MsgType::TestRequest,
+			"SENDER".to_string(),
+			"TARGET".to_string(),
+			10,
+			"20241201-12:00:00.000".to_string(),
+		)
+		.poss_dup_flag(true)
+		.poss_resend(false)
+		.orig_sending_time("20241201-11:59:00.000".to_string())
+		.build();
 
-        assert_eq!(message.poss_dup_flag, Some(true));
-        assert_eq!(message.poss_resend, Some(false));
-        assert_eq!(
-            message.orig_sending_time,
-            Some("20241201-11:59:00.000".to_string())
-        );
-    }
+		assert_eq!(message.poss_dup_flag, Some(true));
+		assert_eq!(message.poss_resend, Some(false));
+		assert_eq!(message.orig_sending_time, Some("20241201-11:59:00.000".to_string()));
+	}
 }
 
 #[cfg(test)]
 mod serialization_tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn test_simple_message_serialization() {
-        let message = FixMessage::builder(
-            MsgType::Heartbeat,
-            "CLIENT".to_string(),
-            "SERVER".to_string(),
-            1,
-            "20241201-12:00:00.000".to_string(),
-        )
-        .build();
+	#[test]
+	fn test_simple_message_serialization() {
+		let message = FixMessage::builder(
+			MsgType::Heartbeat,
+			"CLIENT".to_string(),
+			"SERVER".to_string(),
+			1,
+			"20241201-12:00:00.000".to_string(),
+		)
+		.build();
 
-        let fix_string = message.to_fix_string();
+		let fix_string = message.to_fix_string();
 
-        // Should contain all required fields
-        assert!(fix_string.contains("8=FIX.4.2"));
-        assert!(fix_string.contains("35=0")); // Heartbeat
-        assert!(fix_string.contains("34=1")); // Seq num
-        assert!(fix_string.contains("49=CLIENT"));
-        assert!(fix_string.contains("56=SERVER"));
-        assert!(fix_string.contains("52=20241201-12:00:00.000"));
-        assert!(fix_string.contains("10=")); // Checksum
-    }
+		// Should contain all required fields
+		assert!(fix_string.contains("8=FIX.4.2"));
+		assert!(fix_string.contains("35=0")); // Heartbeat
+		assert!(fix_string.contains("34=1")); // Seq num
+		assert!(fix_string.contains("49=CLIENT"));
+		assert!(fix_string.contains("56=SERVER"));
+		assert!(fix_string.contains("52=20241201-12:00:00.000"));
+		assert!(fix_string.contains("10=")); // Checksum
+	}
 
-    #[test]
-    fn test_new_order_single_serialization() {
-        let message = FixMessage::builder(
-            MsgType::NewOrderSingle,
-            "TESTBUY3".to_string(),
-            "TESTSELL3".to_string(),
-            972,
-            "20190206-16:25:10.403".to_string(),
-        )
-        .cl_ord_id("14163685067084226997921".to_string())
-        .order_qty(100.0)
-        .ord_type("1".to_string()) // Market order
-        .side(Side::Buy)
-        .symbol("AAPL".to_string())
-        .field(60, "20190206-16:25:08.968".to_string()) // TransactTime
-        .field(207, "TO".to_string()) // SecurityExchange
-        .field(6000, "TEST1234".to_string()) // Custom field
-        .build();
+	#[test]
+	fn test_new_order_single_serialization() {
+		let message = FixMessage::builder(
+			MsgType::NewOrderSingle,
+			"TESTBUY3".to_string(),
+			"TESTSELL3".to_string(),
+			972,
+			"20190206-16:25:10.403".to_string(),
+		)
+		.cl_ord_id("14163685067084226997921".to_string())
+		.order_qty(100.0)
+		.ord_type("1".to_string()) // Market order
+		.side(Side::Buy)
+		.symbol("AAPL".to_string())
+		.field(60, "20190206-16:25:08.968".to_string()) // TransactTime
+		.field(207, "TO".to_string()) // SecurityExchange
+		.field(6000, "TEST1234".to_string()) // Custom field
+		.build();
 
-        let fix_string = message.to_fix_string();
+		let fix_string = message.to_fix_string();
 
-        // Verify key fields are present
-        assert!(fix_string.contains("8=FIX.4.2"));
-        assert!(fix_string.contains("35=D")); // NewOrderSingle
-        assert!(fix_string.contains("34=972"));
-        assert!(fix_string.contains("49=TESTBUY3"));
-        assert!(fix_string.contains("56=TESTSELL3"));
-        assert!(fix_string.contains("11=14163685067084226997921"));
-        assert!(fix_string.contains("38=100"));
-        assert!(fix_string.contains("40=1"));
-        assert!(fix_string.contains("54=1"));
-        assert!(fix_string.contains("55=AAPL"));
-        assert!(fix_string.contains("60=20190206-16:25:08.968"));
-        assert!(fix_string.contains("207=TO"));
-        assert!(fix_string.contains("6000=TEST1234"));
-    }
+		// Verify key fields are present
+		assert!(fix_string.contains("8=FIX.4.2"));
+		assert!(fix_string.contains("35=D")); // NewOrderSingle
+		assert!(fix_string.contains("34=972"));
+		assert!(fix_string.contains("49=TESTBUY3"));
+		assert!(fix_string.contains("56=TESTSELL3"));
+		assert!(fix_string.contains("11=14163685067084226997921"));
+		assert!(fix_string.contains("38=100"));
+		assert!(fix_string.contains("40=1"));
+		assert!(fix_string.contains("54=1"));
+		assert!(fix_string.contains("55=AAPL"));
+		assert!(fix_string.contains("60=20190206-16:25:08.968"));
+		assert!(fix_string.contains("207=TO"));
+		assert!(fix_string.contains("6000=TEST1234"));
+	}
 
-    #[test]
-    fn test_execution_report_serialization() {
-        let message = FixMessage::builder(
-            MsgType::ExecutionReport,
-            "BROKER".to_string(),
-            "CLIENT".to_string(),
-            100,
-            "20241201-10:30:00.000".to_string(),
-        )
-        .cl_ord_id("ORDER_123".to_string())
-        .order_id("BROKER_456".to_string())
-        .exec_id("EXEC_789".to_string())
-        .exec_type("F".to_string())
-        .ord_status(OrdStatus::Filled)
-        .symbol("MSFT".to_string())
-        .side(Side::Buy)
-        .order_qty(500.0)
-        .last_qty(500.0)
-        .last_px(300.25)
-        .leaves_qty(0.0)
-        .cum_qty(500.0)
-        .avg_px(300.25)
-        .build();
+	#[test]
+	fn test_execution_report_serialization() {
+		let message = FixMessage::builder(
+			MsgType::ExecutionReport,
+			"BROKER".to_string(),
+			"CLIENT".to_string(),
+			100,
+			"20241201-10:30:00.000".to_string(),
+		)
+		.cl_ord_id("ORDER_123".to_string())
+		.order_id("BROKER_456".to_string())
+		.exec_id("EXEC_789".to_string())
+		.exec_type("F".to_string())
+		.ord_status(OrdStatus::Filled)
+		.symbol("MSFT".to_string())
+		.side(Side::Buy)
+		.order_qty(500.0)
+		.last_qty(500.0)
+		.last_px(300.25)
+		.leaves_qty(0.0)
+		.cum_qty(500.0)
+		.avg_px(300.25)
+		.build();
 
-        let fix_string = message.to_fix_string();
+		let fix_string = message.to_fix_string();
 
-        assert!(fix_string.contains("35=8")); // ExecutionReport
-        assert!(fix_string.contains("11=ORDER_123"));
-        assert!(fix_string.contains("37=BROKER_456"));
-        assert!(fix_string.contains("17=EXEC_789"));
-        assert!(fix_string.contains("150=F"));
-        assert!(fix_string.contains("39=2")); // Filled
-        assert!(fix_string.contains("55=MSFT"));
-        assert!(fix_string.contains("54=1")); // Buy
-        assert!(fix_string.contains("38=500"));
-        assert!(fix_string.contains("32=500"));
-        assert!(fix_string.contains("31=300.25"));
-    }
+		assert!(fix_string.contains("35=8")); // ExecutionReport
+		assert!(fix_string.contains("11=ORDER_123"));
+		assert!(fix_string.contains("37=BROKER_456"));
+		assert!(fix_string.contains("17=EXEC_789"));
+		assert!(fix_string.contains("150=F"));
+		assert!(fix_string.contains("39=2")); // Filled
+		assert!(fix_string.contains("55=MSFT"));
+		assert!(fix_string.contains("54=1")); // Buy
+		assert!(fix_string.contains("38=500"));
+		assert!(fix_string.contains("32=500"));
+		assert!(fix_string.contains("31=300.25"));
+	}
 
-    #[test]
-    fn test_checksum_calculation() {
-        let message = FixMessage::builder(
-            MsgType::Heartbeat,
-            "TEST".to_string(),
-            "DEST".to_string(),
-            1,
-            "20241201-12:00:00.000".to_string(),
-        )
-        .build();
+	#[test]
+	fn test_checksum_calculation() {
+		let message = FixMessage::builder(
+			MsgType::Heartbeat,
+			"TEST".to_string(),
+			"DEST".to_string(),
+			1,
+			"20241201-12:00:00.000".to_string(),
+		)
+		.build();
 
-        let fix_string = message.to_fix_string();
-        let checksum_part = fix_string.split("10=").nth(1).unwrap_or("");
-        let checksum_str = checksum_part.split('\x01').next().unwrap_or("");
+		let fix_string = message.to_fix_string();
+		let checksum_part = fix_string.split("10=").nth(1).unwrap_or("");
+		let checksum_str = checksum_part.split('\x01').next().unwrap_or("");
 
-        // Checksum should be a 3-digit number
-        assert_eq!(checksum_str.len(), 3);
-        assert!(checksum_str.parse::<u32>().is_ok());
-    }
+		// Checksum should be a 3-digit number
+		assert_eq!(checksum_str.len(), 3);
+		assert!(checksum_str.parse::<u32>().is_ok());
+	}
 
-    #[test]
-    fn test_body_length_calculation() {
-        let message = FixMessage::builder(
-            MsgType::NewOrderSingle,
-            "SENDER".to_string(),
-            "TARGET".to_string(),
-            1,
-            "20241201-12:00:00.000".to_string(),
-        )
-        .cl_ord_id("TEST123".to_string())
-        .symbol("AAPL".to_string())
-        .build();
+	#[test]
+	fn test_body_length_calculation() {
+		let message = FixMessage::builder(
+			MsgType::NewOrderSingle,
+			"SENDER".to_string(),
+			"TARGET".to_string(),
+			1,
+			"20241201-12:00:00.000".to_string(),
+		)
+		.cl_ord_id("TEST123".to_string())
+		.symbol("AAPL".to_string())
+		.build();
 
-        let fix_string = message.to_fix_string();
+		let fix_string = message.to_fix_string();
 
-        // Extract body length from the message
-        let body_length_part = fix_string.split("9=").nth(1).unwrap();
-        let body_length_str = body_length_part.split('\x01').next().unwrap();
-        let body_length: usize = body_length_str.parse().unwrap();
+		// Extract body length from the message
+		let body_length_part = fix_string.split("9=").nth(1).unwrap();
+		let body_length_str = body_length_part.split('\x01').next().unwrap();
+		let body_length: usize = body_length_str.parse().unwrap();
 
-        // Body length should be reasonable (not zero, not huge)
-        assert!(body_length > 0);
-        assert!(body_length < 10000); // Reasonable upper bound for test
-    }
+		// Body length should be reasonable (not zero, not huge)
+		assert!(body_length > 0);
+		assert!(body_length < 10000); // Reasonable upper bound for test
+	}
 
-    #[test]
-    fn test_field_ordering() {
-        let message = FixMessage::builder(
-            MsgType::NewOrderSingle,
-            "SENDER".to_string(),
-            "TARGET".to_string(),
-            1,
-            "20241201-12:00:00.000".to_string(),
-        )
-        .field(6000, "CUSTOM1".to_string())
-        .field(207, "EXCHANGE".to_string())
-        .field(9999, "CUSTOM2".to_string())
-        .build();
+	#[test]
+	fn test_field_ordering() {
+		let message = FixMessage::builder(
+			MsgType::NewOrderSingle,
+			"SENDER".to_string(),
+			"TARGET".to_string(),
+			1,
+			"20241201-12:00:00.000".to_string(),
+		)
+		.field(6000, "CUSTOM1".to_string())
+		.field(207, "EXCHANGE".to_string())
+		.field(9999, "CUSTOM2".to_string())
+		.build();
 
-        let fix_string = message.to_fix_string();
+		let fix_string = message.to_fix_string();
 
-        // Custom fields should appear in order
-        let pos_207 = fix_string.find("207=EXCHANGE").unwrap();
-        let pos_6000 = fix_string.find("6000=CUSTOM1").unwrap();
-        let pos_9999 = fix_string.find("9999=CUSTOM2").unwrap();
+		// Custom fields should appear in order
+		let pos_207 = fix_string.find("207=EXCHANGE").unwrap();
+		let pos_6000 = fix_string.find("6000=CUSTOM1").unwrap();
+		let pos_9999 = fix_string.find("9999=CUSTOM2").unwrap();
 
-        assert!(pos_207 < pos_6000);
-        assert!(pos_6000 < pos_9999);
-    }
+		assert!(pos_207 < pos_6000);
+		assert!(pos_6000 < pos_9999);
+	}
 }
 
 #[cfg(test)]
 mod parsing_tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn test_parse_simple_message() {
-        // Create a simple heartbeat message
-        let original = FixMessage::builder(
-            MsgType::Heartbeat,
-            "CLIENT".to_string(),
-            "SERVER".to_string(),
-            1,
-            "20241201-12:00:00.000".to_string(),
-        )
-        .build();
+	#[test]
+	fn test_parse_simple_message() {
+		// Create a simple heartbeat message
+		let original = FixMessage::builder(
+			MsgType::Heartbeat,
+			"CLIENT".to_string(),
+			"SERVER".to_string(),
+			1,
+			"20241201-12:00:00.000".to_string(),
+		)
+		.build();
 
-        let fix_string = original.to_fix_string();
-        let parsed = FixMessage::from_fix_string(&fix_string).unwrap();
+		let fix_string = original.to_fix_string();
+		let parsed = FixMessage::from_fix_string(&fix_string).unwrap();
 
-        assert_eq!(parsed.begin_string, "FIX.4.2");
-        assert_eq!(parsed.msg_type, MsgType::Heartbeat);
-        assert_eq!(parsed.sender_comp_id, "CLIENT");
-        assert_eq!(parsed.target_comp_id, "SERVER");
-        assert_eq!(parsed.msg_seq_num, 1);
-        assert_eq!(parsed.sending_time, "20241201-12:00:00.000");
-    }
+		assert_eq!(parsed.begin_string, "FIX.4.2");
+		assert_eq!(parsed.msg_type, MsgType::Heartbeat);
+		assert_eq!(parsed.sender_comp_id, "CLIENT");
+		assert_eq!(parsed.target_comp_id, "SERVER");
+		assert_eq!(parsed.msg_seq_num, 1);
+		assert_eq!(parsed.sending_time, "20241201-12:00:00.000");
+	}
 
-    #[test]
-    fn test_parse_new_order_single() {
-        let fix_message = "8=FIX.4.2\x019=100\x0135=D\x0134=1\x0149=CLIENT\x0152=20241201-12:00:00.000\x0156=BROKER\x0111=ORDER123\x0138=100\x0140=2\x0154=1\x0155=AAPL\x0144=150.25\x0110=123\x01";
+	#[test]
+	fn test_parse_new_order_single() {
+		let fix_message = "8=FIX.4.2\x019=100\x0135=D\x0134=1\x0149=CLIENT\x0152=20241201-12:00:00.000\x0156=BROKER\x0111=ORDER123\x0138=100\x0140=2\x0154=1\x0155=AAPL\x0144=150.25\x0110=123\x01";
 
-        let parsed = FixMessage::from_fix_string(fix_message).unwrap();
+		let parsed = FixMessage::from_fix_string(fix_message).unwrap();
 
-        assert_eq!(parsed.msg_type, MsgType::NewOrderSingle);
-        assert_eq!(parsed.cl_ord_id, Some("ORDER123".to_string()));
-        assert_eq!(parsed.order_qty, Some(100.0));
-        assert_eq!(parsed.ord_type, Some("2".to_string()));
-        assert_eq!(parsed.side, Some(Side::Buy));
-        assert_eq!(parsed.symbol, Some("AAPL".to_string()));
-        assert_eq!(parsed.price, Some(150.25));
-    }
+		assert_eq!(parsed.msg_type, MsgType::NewOrderSingle);
+		assert_eq!(parsed.cl_ord_id, Some("ORDER123".to_string()));
+		assert_eq!(parsed.order_qty, Some(100.0));
+		assert_eq!(parsed.ord_type, Some("2".to_string()));
+		assert_eq!(parsed.side, Some(Side::Buy));
+		assert_eq!(parsed.symbol, Some("AAPL".to_string()));
+		assert_eq!(parsed.price, Some(150.25));
+	}
 
-    #[test]
-    fn test_parse_with_custom_fields() {
-        let fix_message = "8=FIX.4.2\x019=50\x0135=8\x0134=1\x0149=BROKER\x0152=20241201-12:00:00.000\x0156=CLIENT\x01207=NASDAQ\x016000=CUSTOM\x0110=123\x01";
+	#[test]
+	fn test_parse_with_custom_fields() {
+		let fix_message = "8=FIX.4.2\x019=50\x0135=8\x0134=1\x0149=BROKER\x0152=20241201-12:00:00.000\x0156=CLIENT\x01207=NASDAQ\x016000=CUSTOM\x0110=123\x01";
 
-        let parsed = FixMessage::from_fix_string(fix_message).unwrap();
+		let parsed = FixMessage::from_fix_string(fix_message).unwrap();
 
-        assert_eq!(parsed.msg_type, MsgType::ExecutionReport);
-        assert_eq!(parsed.get_field(207), Some(&"NASDAQ".to_string()));
-        assert_eq!(parsed.get_field(6000), Some(&"CUSTOM".to_string()));
-    }
+		assert_eq!(parsed.msg_type, MsgType::ExecutionReport);
+		assert_eq!(parsed.get_field(207), Some(&"NASDAQ".to_string()));
+		assert_eq!(parsed.get_field(6000), Some(&"CUSTOM".to_string()));
+	}
 
-    #[test]
-    fn test_parse_empty_message() {
-        let result = FixMessage::from_fix_string("");
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), "Empty FIX message");
-    }
+	#[test]
+	fn test_parse_empty_message() {
+		let result = FixMessage::from_fix_string("");
+		assert!(result.is_err());
+		assert_eq!(result.unwrap_err(), "Empty FIX message");
+	}
 
-    #[test]
-    fn test_parse_malformed_field() {
-        let fix_message = "8=FIX.4.2\x01INVALID_FIELD\x0135=0\x0110=123\x01";
-        let parsed = FixMessage::from_fix_string(fix_message);
+	#[test]
+	fn test_parse_malformed_field() {
+		let fix_message = "8=FIX.4.2\x01INVALID_FIELD\x0135=0\x0110=123\x01";
+		let parsed = FixMessage::from_fix_string(fix_message);
 
-        // Should handle malformed fields gracefully by skipping them
-        assert!(parsed.is_ok());
-    }
+		// Should handle malformed fields gracefully by skipping them
+		assert!(parsed.is_ok());
+	}
 
-    #[test]
-    fn test_round_trip_serialization() {
-        let original = FixMessage::builder(
-            MsgType::ExecutionReport,
-            "EXCHANGE".to_string(),
-            "CLIENT".to_string(),
-            500,
-            "20241201-15:30:00.000".to_string(),
-        )
-        .cl_ord_id("CLIENT_ORDER_789".to_string())
-        .symbol("NVDA".to_string())
-        .side(Side::Sell)
-        .order_qty(150.0)
-        .ord_status(OrdStatus::PartiallyFilled)
-        .field(207, "NASDAQ".to_string())
-        .field(6000, "CUSTOM_DATA".to_string())
-        .build();
+	#[test]
+	fn test_round_trip_serialization() {
+		let original = FixMessage::builder(
+			MsgType::ExecutionReport,
+			"EXCHANGE".to_string(),
+			"CLIENT".to_string(),
+			500,
+			"20241201-15:30:00.000".to_string(),
+		)
+		.cl_ord_id("CLIENT_ORDER_789".to_string())
+		.symbol("NVDA".to_string())
+		.side(Side::Sell)
+		.order_qty(150.0)
+		.ord_status(OrdStatus::PartiallyFilled)
+		.field(207, "NASDAQ".to_string())
+		.field(6000, "CUSTOM_DATA".to_string())
+		.build();
 
-        let fix_string = original.to_fix_string();
-        let parsed = FixMessage::from_fix_string(&fix_string).unwrap();
+		let fix_string = original.to_fix_string();
+		let parsed = FixMessage::from_fix_string(&fix_string).unwrap();
 
-        // Core fields should match
-        assert_eq!(parsed.msg_type, original.msg_type);
-        assert_eq!(parsed.sender_comp_id, original.sender_comp_id);
-        assert_eq!(parsed.target_comp_id, original.target_comp_id);
-        assert_eq!(parsed.cl_ord_id, original.cl_ord_id);
-        assert_eq!(parsed.symbol, original.symbol);
-        assert_eq!(parsed.side, original.side);
-        assert_eq!(parsed.order_qty, original.order_qty);
-        assert_eq!(parsed.ord_status, original.ord_status);
+		// Core fields should match
+		assert_eq!(parsed.msg_type, original.msg_type);
+		assert_eq!(parsed.sender_comp_id, original.sender_comp_id);
+		assert_eq!(parsed.target_comp_id, original.target_comp_id);
+		assert_eq!(parsed.cl_ord_id, original.cl_ord_id);
+		assert_eq!(parsed.symbol, original.symbol);
+		assert_eq!(parsed.side, original.side);
+		assert_eq!(parsed.order_qty, original.order_qty);
+		assert_eq!(parsed.ord_status, original.ord_status);
 
-        // Custom fields should match
-        assert_eq!(parsed.get_field(207), original.get_field(207));
-        assert_eq!(parsed.get_field(6000), original.get_field(6000));
-    }
+		// Custom fields should match
+		assert_eq!(parsed.get_field(207), original.get_field(207));
+		assert_eq!(parsed.get_field(6000), original.get_field(6000));
+	}
 }
 
 #[cfg(test)]
 mod real_world_examples {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn test_user_provided_message_structure() {
-        // Recreate the message structure from the user's example:
-        // "8=FIX.4.29=16335=D34=97249=TESTBUY352=20190206-16:25:10.40356=TESTSELL311=14163685067084226997921=238=10040=154=155=AAPL60=20190206-16:25:08.968207=TO6000=TEST123410=106"
+	#[test]
+	fn test_user_provided_message_structure() {
+		// Recreate the message structure from the user's example:
+		// "8=FIX.4.29=16335=D34=97249=TESTBUY352=20190206-16:25:10.40356=TESTSELL311=14163685067084226997921=238=10040=154=155=AAPL60=20190206-16:25:08.968207=TO6000=TEST123410=106"
 
-        let message = FixMessage::builder(
-            MsgType::NewOrderSingle,
-            "TESTBUY3".to_string(),
-            "TESTSELL3".to_string(),
-            972,
-            "20190206-16:25:10.403".to_string(),
-        )
-        .cl_ord_id("14163685067084226997921".to_string())
-        .field(21, "2".to_string()) // HandlInst
-        .order_qty(100.0)
-        .ord_type("1".to_string()) // Market order
-        .side(Side::Buy)
-        .symbol("AAPL".to_string())
-        .field(60, "20190206-16:25:08.968".to_string()) // TransactTime
-        .field(207, "TO".to_string()) // SecurityExchange
-        .field(6000, "TEST1234".to_string()) // Custom field
-        .build();
+		let message = FixMessage::builder(
+			MsgType::NewOrderSingle,
+			"TESTBUY3".to_string(),
+			"TESTSELL3".to_string(),
+			972,
+			"20190206-16:25:10.403".to_string(),
+		)
+		.cl_ord_id("14163685067084226997921".to_string())
+		.field(21, "2".to_string()) // HandlInst
+		.order_qty(100.0)
+		.ord_type("1".to_string()) // Market order
+		.side(Side::Buy)
+		.symbol("AAPL".to_string())
+		.field(60, "20190206-16:25:08.968".to_string()) // TransactTime
+		.field(207, "TO".to_string()) // SecurityExchange
+		.field(6000, "TEST1234".to_string()) // Custom field
+		.build();
 
-        let fix_string = message.to_fix_string();
+		let fix_string = message.to_fix_string();
 
-        // Verify the structure matches expected format
-        assert!(fix_string.starts_with("8=FIX.4.2\x01"));
-        assert!(fix_string.contains("35=D\x01")); // NewOrderSingle
-        assert!(fix_string.contains("34=972\x01"));
-        assert!(fix_string.contains("49=TESTBUY3\x01"));
-        assert!(fix_string.contains("56=TESTSELL3\x01"));
-        assert!(fix_string.contains("11=14163685067084226997921\x01"));
-        assert!(fix_string.contains("21=2\x01"));
-        assert!(fix_string.contains("38=100\x01"));
-        assert!(fix_string.contains("40=1\x01"));
-        assert!(fix_string.contains("54=1\x01"));
-        assert!(fix_string.contains("55=AAPL\x01"));
-        assert!(fix_string.contains("60=20190206-16:25:08.968\x01"));
-        assert!(fix_string.contains("207=TO\x01"));
-        assert!(fix_string.contains("6000=TEST1234\x01"));
-        // Checksum should be present (not checking exact value as it's calculated)
-        assert!(fix_string.contains("10="));
-    }
+		// Verify the structure matches expected format
+		assert!(fix_string.starts_with("8=FIX.4.2\x01"));
+		assert!(fix_string.contains("35=D\x01")); // NewOrderSingle
+		assert!(fix_string.contains("34=972\x01"));
+		assert!(fix_string.contains("49=TESTBUY3\x01"));
+		assert!(fix_string.contains("56=TESTSELL3\x01"));
+		assert!(fix_string.contains("11=14163685067084226997921\x01"));
+		assert!(fix_string.contains("21=2\x01"));
+		assert!(fix_string.contains("38=100\x01"));
+		assert!(fix_string.contains("40=1\x01"));
+		assert!(fix_string.contains("54=1\x01"));
+		assert!(fix_string.contains("55=AAPL\x01"));
+		assert!(fix_string.contains("60=20190206-16:25:08.968\x01"));
+		assert!(fix_string.contains("207=TO\x01"));
+		assert!(fix_string.contains("6000=TEST1234\x01"));
+		// Checksum should be present (not checking exact value as it's calculated)
+		assert!(fix_string.contains("10="));
+	}
 
-    #[test]
-    fn test_market_data_subscription() {
-        let message = FixMessage::builder(
-            MsgType::MarketDataRequest,
-            "TRADING_SYS".to_string(),
-            "MD_PROVIDER".to_string(),
-            250,
-            "20241201-09:15:00.000".to_string(),
-        )
-        .symbol("SPY".to_string())
-        .field(262, "MD_REQ_001".to_string()) // MDReqID
-        .field(263, "1".to_string()) // SubscriptionRequestType
-        .field(264, "0".to_string()) // MarketDepth
-        .field(265, "1".to_string()) // MDUpdateType
-        .build();
+	#[test]
+	fn test_market_data_subscription() {
+		let message = FixMessage::builder(
+			MsgType::MarketDataRequest,
+			"TRADING_SYS".to_string(),
+			"MD_PROVIDER".to_string(),
+			250,
+			"20241201-09:15:00.000".to_string(),
+		)
+		.symbol("SPY".to_string())
+		.field(262, "MD_REQ_001".to_string()) // MDReqID
+		.field(263, "1".to_string()) // SubscriptionRequestType
+		.field(264, "0".to_string()) // MarketDepth
+		.field(265, "1".to_string()) // MDUpdateType
+		.build();
 
-        let fix_string = message.to_fix_string();
-        assert!(fix_string.contains("35=V")); // MarketDataRequest
-        assert!(fix_string.contains("55=SPY"));
-        assert!(fix_string.contains("262=MD_REQ_001"));
+		let fix_string = message.to_fix_string();
+		assert!(fix_string.contains("35=V")); // MarketDataRequest
+		assert!(fix_string.contains("55=SPY"));
+		assert!(fix_string.contains("262=MD_REQ_001"));
 
-        // Test parsing back
-        let parsed = FixMessage::from_fix_string(&fix_string).unwrap();
-        assert_eq!(parsed.msg_type, MsgType::MarketDataRequest);
-        assert_eq!(parsed.symbol, Some("SPY".to_string()));
-        assert_eq!(parsed.get_field(262), Some(&"MD_REQ_001".to_string()));
-    }
+		// Test parsing back
+		let parsed = FixMessage::from_fix_string(&fix_string).unwrap();
+		assert_eq!(parsed.msg_type, MsgType::MarketDataRequest);
+		assert_eq!(parsed.symbol, Some("SPY".to_string()));
+		assert_eq!(parsed.get_field(262), Some(&"MD_REQ_001".to_string()));
+	}
 
-    #[cfg(test)]
-    mod fromstr_display_tests {
-        use super::*;
+	#[cfg(test)]
+	mod fromstr_display_tests {
+		use super::*;
 
-        #[test]
-        fn test_fromstr_trait_usage() {
-            // Test clean FromStr usage for MsgType
-            let heartbeat: MsgType = "0".parse().unwrap();
-            let new_order: MsgType = "D".parse().unwrap();
-            let exec_report: MsgType = "8".parse().unwrap();
+		#[test]
+		fn test_fromstr_trait_usage() {
+			// Test clean FromStr usage for MsgType
+			let heartbeat: MsgType = "0".parse().unwrap();
+			let new_order: MsgType = "D".parse().unwrap();
+			let exec_report: MsgType = "8".parse().unwrap();
 
-            assert_eq!(heartbeat, MsgType::Heartbeat);
-            assert_eq!(new_order, MsgType::NewOrderSingle);
-            assert_eq!(exec_report, MsgType::ExecutionReport);
+			assert_eq!(heartbeat, MsgType::Heartbeat);
+			assert_eq!(new_order, MsgType::NewOrderSingle);
+			assert_eq!(exec_report, MsgType::ExecutionReport);
 
-            // Test clean FromStr usage for Side
-            let buy_side: Side = "1".parse().unwrap();
-            let sell_side: Side = "2".parse().unwrap();
+			// Test clean FromStr usage for Side
+			let buy_side: Side = "1".parse().unwrap();
+			let sell_side: Side = "2".parse().unwrap();
 
-            assert_eq!(buy_side, Side::Buy);
-            assert_eq!(sell_side, Side::Sell);
+			assert_eq!(buy_side, Side::Buy);
+			assert_eq!(sell_side, Side::Sell);
 
-            // Test clean FromStr usage for OrdStatus
-            let new_status: OrdStatus = "0".parse().unwrap();
-            let filled_status: OrdStatus = "2".parse().unwrap();
-            let pending_new: OrdStatus = "A".parse().unwrap();
+			// Test clean FromStr usage for OrdStatus
+			let new_status: OrdStatus = "0".parse().unwrap();
+			let filled_status: OrdStatus = "2".parse().unwrap();
+			let pending_new: OrdStatus = "A".parse().unwrap();
 
-            assert_eq!(new_status, OrdStatus::New);
-            assert_eq!(filled_status, OrdStatus::Filled);
-            assert_eq!(pending_new, OrdStatus::PendingNew);
-        }
+			assert_eq!(new_status, OrdStatus::New);
+			assert_eq!(filled_status, OrdStatus::Filled);
+			assert_eq!(pending_new, OrdStatus::PendingNew);
+		}
 
-        #[test]
-        fn test_display_trait_usage() {
-            // Test Display trait for MsgType
-            assert_eq!(format!("{}", MsgType::Heartbeat), "0");
-            assert_eq!(format!("{}", MsgType::NewOrderSingle), "D");
-            assert_eq!(format!("{}", MsgType::ExecutionReport), "8");
-            assert_eq!(
-                format!("{}", MsgType::Other("CUSTOM".to_string())),
-                "CUSTOM"
-            );
+		#[test]
+		fn test_display_trait_usage() {
+			// Test Display trait for MsgType
+			assert_eq!(format!("{}", MsgType::Heartbeat), "0");
+			assert_eq!(format!("{}", MsgType::NewOrderSingle), "D");
+			assert_eq!(format!("{}", MsgType::ExecutionReport), "8");
+			assert_eq!(format!("{}", MsgType::Other("CUSTOM".to_string())), "CUSTOM");
 
-            // Test Display trait for Side
-            assert_eq!(format!("{}", Side::Buy), "1");
-            assert_eq!(format!("{}", Side::Sell), "2");
+			// Test Display trait for Side
+			assert_eq!(format!("{}", Side::Buy), "1");
+			assert_eq!(format!("{}", Side::Sell), "2");
 
-            // Test Display trait for OrdStatus
-            assert_eq!(format!("{}", OrdStatus::New), "0");
-            assert_eq!(format!("{}", OrdStatus::Filled), "2");
-            assert_eq!(format!("{}", OrdStatus::PendingNew), "A");
-            assert_eq!(format!("{}", OrdStatus::PendingReplace), "E");
-        }
+			// Test Display trait for OrdStatus
+			assert_eq!(format!("{}", OrdStatus::New), "0");
+			assert_eq!(format!("{}", OrdStatus::Filled), "2");
+			assert_eq!(format!("{}", OrdStatus::PendingNew), "A");
+			assert_eq!(format!("{}", OrdStatus::PendingReplace), "E");
+		}
 
-        #[test]
-        fn test_error_handling_with_fromstr() {
-            // Test error handling for invalid values
-            assert!(MsgType::from_str("INVALID").is_ok()); // MsgType never fails, creates Other
-            assert!(Side::from_str("invalid").is_err());
-            assert!(OrdStatus::from_str("invalid").is_err());
+		#[test]
+		fn test_error_handling_with_fromstr() {
+			// Test error handling for invalid values
+			assert!(MsgType::from_str("INVALID").is_ok()); // MsgType never fails, creates Other
+			assert!(Side::from_str("invalid").is_err());
+			assert!(OrdStatus::from_str("invalid").is_err());
 
-            // Test that MsgType::Other handles any string
-            let custom_msg: MsgType = "CUSTOM_TYPE".parse().unwrap();
-            match custom_msg {
-                MsgType::Other(s) => assert_eq!(s, "CUSTOM_TYPE"),
-                _ => panic!("Expected Other variant"),
-            }
-        }
+			// Test that MsgType::Other handles any string
+			let custom_msg: MsgType = "CUSTOM_TYPE".parse().unwrap();
+			match custom_msg {
+				MsgType::Other(s) => assert_eq!(s, "CUSTOM_TYPE"),
+				_ => panic!("Expected Other variant"),
+			}
+		}
 
-        #[test]
-        fn test_builder_with_parsed_enums() {
-            // Demonstrate using parsed enums in builder pattern
-            let msg_type: MsgType = "D".parse().unwrap();
-            let side: Side = "1".parse().unwrap();
-            let ord_status: OrdStatus = "0".parse().unwrap();
+		#[test]
+		fn test_builder_with_parsed_enums() {
+			// Demonstrate using parsed enums in builder pattern
+			let msg_type: MsgType = "D".parse().unwrap();
+			let side: Side = "1".parse().unwrap();
+			let ord_status: OrdStatus = "0".parse().unwrap();
 
-            let message = FixMessage::builder(
-                msg_type,
-                "TRADER".to_string(),
-                "EXCHANGE".to_string(),
-                1,
-                "20241201-12:00:00.000".to_string(),
-            )
-            .side(side)
-            .ord_status(ord_status)
-            .build();
+			let message = FixMessage::builder(
+				msg_type,
+				"TRADER".to_string(),
+				"EXCHANGE".to_string(),
+				1,
+				"20241201-12:00:00.000".to_string(),
+			)
+			.side(side)
+			.ord_status(ord_status)
+			.build();
 
-            assert_eq!(message.msg_type, MsgType::NewOrderSingle);
-            assert_eq!(message.side, Some(Side::Buy));
-            assert_eq!(message.ord_status, Some(OrdStatus::New));
-        }
+			assert_eq!(message.msg_type, MsgType::NewOrderSingle);
+			assert_eq!(message.side, Some(Side::Buy));
+			assert_eq!(message.ord_status, Some(OrdStatus::New));
+		}
 
-        #[test]
-        fn test_round_trip_with_display_and_fromstr() {
-            let original_types = vec![
-                MsgType::Heartbeat,
-                MsgType::NewOrderSingle,
-                MsgType::ExecutionReport,
-                MsgType::Other("CUSTOM".to_string()),
-            ];
+		#[test]
+		fn test_round_trip_with_display_and_fromstr() {
+			let original_types = vec![
+				MsgType::Heartbeat,
+				MsgType::NewOrderSingle,
+				MsgType::ExecutionReport,
+				MsgType::Other("CUSTOM".to_string()),
+			];
 
-            for original in original_types {
-                let display_str = format!("{}", original);
-                let parsed: MsgType = display_str.parse().unwrap();
-                assert_eq!(original, parsed);
-            }
+			for original in original_types {
+				let display_str = format!("{}", original);
+				let parsed: MsgType = display_str.parse().unwrap();
+				assert_eq!(original, parsed);
+			}
 
-            let original_sides = vec![Side::Buy, Side::Sell];
-            for original in original_sides {
-                let display_str = format!("{}", original);
-                let parsed: Side = display_str.parse().unwrap();
-                assert_eq!(original, parsed);
-            }
+			let original_sides = vec![Side::Buy, Side::Sell];
+			for original in original_sides {
+				let display_str = format!("{}", original);
+				let parsed: Side = display_str.parse().unwrap();
+				assert_eq!(original, parsed);
+			}
 
-            let original_statuses = vec![
-                OrdStatus::New,
-                OrdStatus::Filled,
-                OrdStatus::PendingNew,
-                OrdStatus::PendingReplace,
-            ];
-            for original in original_statuses {
-                let display_str = format!("{}", original);
-                let parsed: OrdStatus = display_str.parse().unwrap();
-                assert_eq!(original, parsed);
-            }
-        }
+			let original_statuses =
+				vec![OrdStatus::New, OrdStatus::Filled, OrdStatus::PendingNew, OrdStatus::PendingReplace];
+			for original in original_statuses {
+				let display_str = format!("{}", original);
+				let parsed: OrdStatus = display_str.parse().unwrap();
+				assert_eq!(original, parsed);
+			}
+		}
 
-        #[test]
-        fn test_automatic_string_conversion() {
-            // Demonstrate that Display automatically provides to_string()
-            let msg_type = MsgType::NewOrderSingle;
-            let side = Side::Buy;
-            let ord_status = OrdStatus::Filled;
+		#[test]
+		fn test_automatic_string_conversion() {
+			// Demonstrate that Display automatically provides to_string()
+			let msg_type = MsgType::NewOrderSingle;
+			let side = Side::Buy;
+			let ord_status = OrdStatus::Filled;
 
-            // These conversions work automatically due to Display trait
-            let msg_type_string = msg_type.to_string();
-            let side_string = side.to_string();
-            let ord_status_string = ord_status.to_string();
+			// These conversions work automatically due to Display trait
+			let msg_type_string = msg_type.to_string();
+			let side_string = side.to_string();
+			let ord_status_string = ord_status.to_string();
 
-            assert_eq!(msg_type_string, "D");
-            assert_eq!(side_string, "1");
-            assert_eq!(ord_status_string, "2");
+			assert_eq!(msg_type_string, "D");
+			assert_eq!(side_string, "1");
+			assert_eq!(ord_status_string, "2");
 
-            // Can also use format! macro directly
-            let formatted = format!("{}-{}-{}", msg_type, side, ord_status);
-            assert_eq!(formatted, "D-1-2");
+			// Can also use format! macro directly
+			let formatted = format!("{}-{}-{}", msg_type, side, ord_status);
+			assert_eq!(formatted, "D-1-2");
 
-            // No need for custom to_str() methods - Display trait provides everything
-            assert_eq!(format!("{}", MsgType::ExecutionReport), "8");
-            assert_eq!(MsgType::Heartbeat.to_string(), "0");
-        }
-    }
+			// No need for custom to_str() methods - Display trait provides everything
+			assert_eq!(format!("{}", MsgType::ExecutionReport), "8");
+			assert_eq!(MsgType::Heartbeat.to_string(), "0");
+		}
+	}
 
-    #[test]
-    fn test_order_cancel_request() {
-        let message = FixMessage::builder(
-            MsgType::OrderCancelRequest,
-            "CLIENT_SYS".to_string(),
-            "BROKER_SYS".to_string(),
-            150,
-            "20241201-10:45:00.000".to_string(),
-        )
-        .cl_ord_id("CANCEL_REQ_001".to_string())
-        .field(41, "ORIGINAL_ORDER_123".to_string()) // OrigClOrdID
-        .order_id("BROKER_ORDER_456".to_string())
-        .symbol("TSLA".to_string())
-        .side(Side::Buy)
-        .field(60, "20241201-10:45:00.000".to_string()) // TransactTime
-        .build();
+	#[test]
+	fn test_order_cancel_request() {
+		let message = FixMessage::builder(
+			MsgType::OrderCancelRequest,
+			"CLIENT_SYS".to_string(),
+			"BROKER_SYS".to_string(),
+			150,
+			"20241201-10:45:00.000".to_string(),
+		)
+		.cl_ord_id("CANCEL_REQ_001".to_string())
+		.field(41, "ORIGINAL_ORDER_123".to_string()) // OrigClOrdID
+		.order_id("BROKER_ORDER_456".to_string())
+		.symbol("TSLA".to_string())
+		.side(Side::Buy)
+		.field(60, "20241201-10:45:00.000".to_string()) // TransactTime
+		.build();
 
-        let fix_string = message.to_fix_string();
-        assert!(fix_string.contains("35=F")); // OrderCancelRequest
-        assert!(fix_string.contains("11=CANCEL_REQ_001"));
-        assert!(fix_string.contains("41=ORIGINAL_ORDER_123"));
-        assert!(fix_string.contains("37=BROKER_ORDER_456"));
-        assert!(fix_string.contains("55=TSLA"));
-        assert!(fix_string.contains("54=1")); // Buy side
-    }
+		let fix_string = message.to_fix_string();
+		assert!(fix_string.contains("35=F")); // OrderCancelRequest
+		assert!(fix_string.contains("11=CANCEL_REQ_001"));
+		assert!(fix_string.contains("41=ORIGINAL_ORDER_123"));
+		assert!(fix_string.contains("37=BROKER_ORDER_456"));
+		assert!(fix_string.contains("55=TSLA"));
+		assert!(fix_string.contains("54=1")); // Buy side
+	}
 }

--- a/tests/fix_message_tests.rs
+++ b/tests/fix_message_tests.rs
@@ -3,420 +3,414 @@ use std::str::FromStr;
 
 #[cfg(test)]
 mod msg_type_tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn test_msg_type_from_str_valid_values() {
-        assert_eq!(MsgType::from_str("0").unwrap(), MsgType::Heartbeat);
-        assert_eq!(MsgType::from_str("1").unwrap(), MsgType::TestRequest);
-        assert_eq!(MsgType::from_str("8").unwrap(), MsgType::ExecutionReport);
-        assert_eq!(MsgType::from_str("D").unwrap(), MsgType::NewOrderSingle);
-        assert_eq!(MsgType::from_str("F").unwrap(), MsgType::OrderCancelRequest);
-        assert_eq!(MsgType::from_str("V").unwrap(), MsgType::MarketDataRequest);
-    }
+	#[test]
+	fn test_msg_type_from_str_valid_values() {
+		assert_eq!(MsgType::from_str("0").unwrap(), MsgType::Heartbeat);
+		assert_eq!(MsgType::from_str("1").unwrap(), MsgType::TestRequest);
+		assert_eq!(MsgType::from_str("8").unwrap(), MsgType::ExecutionReport);
+		assert_eq!(MsgType::from_str("D").unwrap(), MsgType::NewOrderSingle);
+		assert_eq!(MsgType::from_str("F").unwrap(), MsgType::OrderCancelRequest);
+		assert_eq!(MsgType::from_str("V").unwrap(), MsgType::MarketDataRequest);
+	}
 
-    #[test]
-    fn test_msg_type_from_str_unknown_value() {
-        match MsgType::from_str("Z").unwrap() {
-            MsgType::Other(s) => assert_eq!(s, "Z"),
-            _ => panic!("Expected Other variant"),
-        }
-    }
+	#[test]
+	fn test_msg_type_from_str_unknown_value() {
+		match MsgType::from_str("Z").unwrap() {
+			MsgType::Other(s) => assert_eq!(s, "Z"),
+			_ => panic!("Expected Other variant"),
+		}
+	}
 
-    #[test]
-    fn test_msg_type_display() {
-        assert_eq!(format!("{}", MsgType::Heartbeat), "0");
-        assert_eq!(format!("{}", MsgType::TestRequest), "1");
-        assert_eq!(format!("{}", MsgType::ExecutionReport), "8");
-        assert_eq!(format!("{}", MsgType::NewOrderSingle), "D");
-        assert_eq!(format!("{}", MsgType::OrderCancelRequest), "F");
-        assert_eq!(format!("{}", MsgType::Other("Z".to_string())), "Z");
-    }
+	#[test]
+	fn test_msg_type_display() {
+		assert_eq!(format!("{}", MsgType::Heartbeat), "0");
+		assert_eq!(format!("{}", MsgType::TestRequest), "1");
+		assert_eq!(format!("{}", MsgType::ExecutionReport), "8");
+		assert_eq!(format!("{}", MsgType::NewOrderSingle), "D");
+		assert_eq!(format!("{}", MsgType::OrderCancelRequest), "F");
+		assert_eq!(format!("{}", MsgType::Other("Z".to_string())), "Z");
+	}
 
-    #[test]
-    fn test_msg_type_round_trip() {
-        let original_types = vec![
-            MsgType::Heartbeat,
-            MsgType::ExecutionReport,
-            MsgType::NewOrderSingle,
-            MsgType::Other("CUSTOM".to_string()),
-        ];
+	#[test]
+	fn test_msg_type_round_trip() {
+		let original_types = vec![
+			MsgType::Heartbeat,
+			MsgType::ExecutionReport,
+			MsgType::NewOrderSingle,
+			MsgType::Other("CUSTOM".to_string()),
+		];
 
-        for msg_type in original_types {
-            let str_repr = format!("{}", msg_type);
-            let parsed = MsgType::from_str(&str_repr).unwrap();
-            assert_eq!(msg_type, parsed);
-        }
-    }
+		for msg_type in original_types {
+			let str_repr = format!("{}", msg_type);
+			let parsed = MsgType::from_str(&str_repr).unwrap();
+			assert_eq!(msg_type, parsed);
+		}
+	}
 }
 
 #[cfg(test)]
 mod side_tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn test_side_from_str_valid() {
-        assert_eq!(Side::from_str("1").unwrap(), Side::Buy);
-        assert_eq!(Side::from_str("2").unwrap(), Side::Sell);
-    }
+	#[test]
+	fn test_side_from_str_valid() {
+		assert_eq!(Side::from_str("1").unwrap(), Side::Buy);
+		assert_eq!(Side::from_str("2").unwrap(), Side::Sell);
+	}
 
-    #[test]
-    fn test_side_from_str_invalid() {
-        assert!(Side::from_str("0").is_err());
-        assert!(Side::from_str("3").is_err());
-        assert!(Side::from_str("B").is_err());
-        assert!(Side::from_str("").is_err());
-    }
+	#[test]
+	fn test_side_from_str_invalid() {
+		assert!(Side::from_str("0").is_err());
+		assert!(Side::from_str("3").is_err());
+		assert!(Side::from_str("B").is_err());
+		assert!(Side::from_str("").is_err());
+	}
 
-    #[test]
-    fn test_side_display() {
-        assert_eq!(format!("{}", Side::Buy), "1");
-        assert_eq!(format!("{}", Side::Sell), "2");
-    }
+	#[test]
+	fn test_side_display() {
+		assert_eq!(format!("{}", Side::Buy), "1");
+		assert_eq!(format!("{}", Side::Sell), "2");
+	}
 
-    #[test]
-    fn test_side_round_trip() {
-        let sides = vec![Side::Buy, Side::Sell];
-        for side in sides {
-            let str_repr = format!("{}", side);
-            let parsed = Side::from_str(&str_repr).unwrap();
-            assert_eq!(side, parsed);
-        }
-    }
+	#[test]
+	fn test_side_round_trip() {
+		let sides = vec![Side::Buy, Side::Sell];
+		for side in sides {
+			let str_repr = format!("{}", side);
+			let parsed = Side::from_str(&str_repr).unwrap();
+			assert_eq!(side, parsed);
+		}
+	}
 }
 
 #[cfg(test)]
 mod ord_status_tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn test_ord_status_from_str_numeric() {
-        assert_eq!(OrdStatus::from_str("0").unwrap(), OrdStatus::New);
-        assert_eq!(
-            OrdStatus::from_str("1").unwrap(),
-            OrdStatus::PartiallyFilled
-        );
-        assert_eq!(OrdStatus::from_str("2").unwrap(), OrdStatus::Filled);
-        assert_eq!(OrdStatus::from_str("4").unwrap(), OrdStatus::Canceled);
-        assert_eq!(OrdStatus::from_str("8").unwrap(), OrdStatus::Rejected);
-    }
+	#[test]
+	fn test_ord_status_from_str_numeric() {
+		assert_eq!(OrdStatus::from_str("0").unwrap(), OrdStatus::New);
+		assert_eq!(OrdStatus::from_str("1").unwrap(), OrdStatus::PartiallyFilled);
+		assert_eq!(OrdStatus::from_str("2").unwrap(), OrdStatus::Filled);
+		assert_eq!(OrdStatus::from_str("4").unwrap(), OrdStatus::Canceled);
+		assert_eq!(OrdStatus::from_str("8").unwrap(), OrdStatus::Rejected);
+	}
 
-    #[test]
-    fn test_ord_status_from_str_alpha() {
-        assert_eq!(OrdStatus::from_str("A").unwrap(), OrdStatus::PendingNew);
-        assert_eq!(OrdStatus::from_str("B").unwrap(), OrdStatus::Calculated);
-        assert_eq!(OrdStatus::from_str("C").unwrap(), OrdStatus::Expired);
-        assert_eq!(
-            OrdStatus::from_str("D").unwrap(),
-            OrdStatus::AcceptedForBidding
-        );
-        assert_eq!(OrdStatus::from_str("E").unwrap(), OrdStatus::PendingReplace);
-    }
+	#[test]
+	fn test_ord_status_from_str_alpha() {
+		assert_eq!(OrdStatus::from_str("A").unwrap(), OrdStatus::PendingNew);
+		assert_eq!(OrdStatus::from_str("B").unwrap(), OrdStatus::Calculated);
+		assert_eq!(OrdStatus::from_str("C").unwrap(), OrdStatus::Expired);
+		assert_eq!(OrdStatus::from_str("D").unwrap(), OrdStatus::AcceptedForBidding);
+		assert_eq!(OrdStatus::from_str("E").unwrap(), OrdStatus::PendingReplace);
+	}
 
-    #[test]
-    fn test_ord_status_from_str_invalid() {
-        assert!(OrdStatus::from_str("F").is_err());
-        assert!(OrdStatus::from_str("Z").is_err());
-        assert!(OrdStatus::from_str("10").is_err());
-        assert!(OrdStatus::from_str("").is_err());
-    }
+	#[test]
+	fn test_ord_status_from_str_invalid() {
+		assert!(OrdStatus::from_str("F").is_err());
+		assert!(OrdStatus::from_str("Z").is_err());
+		assert!(OrdStatus::from_str("10").is_err());
+		assert!(OrdStatus::from_str("").is_err());
+	}
 
-    #[test]
-    fn test_ord_status_display() {
-        assert_eq!(format!("{}", OrdStatus::New), "0");
-        assert_eq!(format!("{}", OrdStatus::Filled), "2");
-        assert_eq!(format!("{}", OrdStatus::Canceled), "4");
-        assert_eq!(format!("{}", OrdStatus::PendingNew), "A");
-        assert_eq!(format!("{}", OrdStatus::PendingReplace), "E");
-    }
+	#[test]
+	fn test_ord_status_display() {
+		assert_eq!(format!("{}", OrdStatus::New), "0");
+		assert_eq!(format!("{}", OrdStatus::Filled), "2");
+		assert_eq!(format!("{}", OrdStatus::Canceled), "4");
+		assert_eq!(format!("{}", OrdStatus::PendingNew), "A");
+		assert_eq!(format!("{}", OrdStatus::PendingReplace), "E");
+	}
 
-    #[test]
-    fn test_ord_status_round_trip() {
-        let statuses = vec![
-            OrdStatus::New,
-            OrdStatus::PartiallyFilled,
-            OrdStatus::Filled,
-            OrdStatus::Canceled,
-            OrdStatus::PendingNew,
-            OrdStatus::PendingReplace,
-        ];
+	#[test]
+	fn test_ord_status_round_trip() {
+		let statuses = vec![
+			OrdStatus::New,
+			OrdStatus::PartiallyFilled,
+			OrdStatus::Filled,
+			OrdStatus::Canceled,
+			OrdStatus::PendingNew,
+			OrdStatus::PendingReplace,
+		];
 
-        for status in statuses {
-            let str_repr = format!("{}", status);
-            let parsed = OrdStatus::from_str(&str_repr).unwrap();
-            assert_eq!(status, parsed);
-        }
-    }
+		for status in statuses {
+			let str_repr = format!("{}", status);
+			let parsed = OrdStatus::from_str(&str_repr).unwrap();
+			assert_eq!(status, parsed);
+		}
+	}
 }
 
 #[cfg(test)]
 mod fix_message_tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn test_new_fix_message_creation() {
-        let msg = FixMessage::new(
-            MsgType::Heartbeat,
-            "SENDER".to_string(),
-            "TARGET".to_string(),
-            123,
-            "20241201-12:00:00.000".to_string(),
-        );
+	#[test]
+	fn test_new_fix_message_creation() {
+		let msg = FixMessage::new(
+			MsgType::Heartbeat,
+			"SENDER".to_string(),
+			"TARGET".to_string(),
+			123,
+			"20241201-12:00:00.000".to_string(),
+		);
 
-        assert_eq!(msg.begin_string, "FIX.4.2");
-        assert_eq!(msg.msg_type, MsgType::Heartbeat);
-        assert_eq!(msg.sender_comp_id, "SENDER");
-        assert_eq!(msg.target_comp_id, "TARGET");
-        assert_eq!(msg.msg_seq_num, 123);
-        assert_eq!(msg.sending_time, "20241201-12:00:00.000");
-        assert_eq!(msg.body_length, 0);
-        assert_eq!(msg.checksum, "000");
-    }
+		assert_eq!(msg.begin_string, "FIX.4.2");
+		assert_eq!(msg.msg_type, MsgType::Heartbeat);
+		assert_eq!(msg.sender_comp_id, "SENDER");
+		assert_eq!(msg.target_comp_id, "TARGET");
+		assert_eq!(msg.msg_seq_num, 123);
+		assert_eq!(msg.sending_time, "20241201-12:00:00.000");
+		assert_eq!(msg.body_length, 0);
+		assert_eq!(msg.checksum, "000");
+	}
 
-    #[test]
-    fn test_default_fix_message() {
-        let msg = FixMessage::default();
+	#[test]
+	fn test_default_fix_message() {
+		let msg = FixMessage::default();
 
-        assert_eq!(msg.begin_string, "FIX.4.2");
-        assert_eq!(msg.msg_type, MsgType::Heartbeat);
-        assert_eq!(msg.sender_comp_id, "SENDER");
-        assert_eq!(msg.target_comp_id, "TARGET");
-        assert_eq!(msg.msg_seq_num, 1);
-        assert_eq!(msg.sending_time, "20240101-00:00:00.000");
-    }
+		assert_eq!(msg.begin_string, "FIX.4.2");
+		assert_eq!(msg.msg_type, MsgType::Heartbeat);
+		assert_eq!(msg.sender_comp_id, "SENDER");
+		assert_eq!(msg.target_comp_id, "TARGET");
+		assert_eq!(msg.msg_seq_num, 1);
+		assert_eq!(msg.sending_time, "20240101-00:00:00.000");
+	}
 
-    #[test]
-    fn test_fix_message_optional_fields() {
-        let mut msg = FixMessage::new(
-            MsgType::NewOrderSingle,
-            "CLIENT".to_string(),
-            "BROKER".to_string(),
-            1,
-            "20241201-12:00:00.000".to_string(),
-        );
+	#[test]
+	fn test_fix_message_optional_fields() {
+		let mut msg = FixMessage::new(
+			MsgType::NewOrderSingle,
+			"CLIENT".to_string(),
+			"BROKER".to_string(),
+			1,
+			"20241201-12:00:00.000".to_string(),
+		);
 
-        // Initially, optional fields should be None
-        assert_eq!(msg.cl_ord_id, None);
-        assert_eq!(msg.symbol, None);
-        assert_eq!(msg.side, None);
-        assert_eq!(msg.order_qty, None);
+		// Initially, optional fields should be None
+		assert_eq!(msg.cl_ord_id, None);
+		assert_eq!(msg.symbol, None);
+		assert_eq!(msg.side, None);
+		assert_eq!(msg.order_qty, None);
 
-        // Set some optional fields
-        msg.cl_ord_id = Some("CLIENT123".to_string());
-        msg.symbol = Some("AAPL".to_string());
-        msg.side = Some(Side::Buy);
-        msg.order_qty = Some(100.0);
+		// Set some optional fields
+		msg.cl_ord_id = Some("CLIENT123".to_string());
+		msg.symbol = Some("AAPL".to_string());
+		msg.side = Some(Side::Buy);
+		msg.order_qty = Some(100.0);
 
-        assert_eq!(msg.cl_ord_id, Some("CLIENT123".to_string()));
-        assert_eq!(msg.symbol, Some("AAPL".to_string()));
-        assert_eq!(msg.side, Some(Side::Buy));
-        assert_eq!(msg.order_qty, Some(100.0));
-    }
+		assert_eq!(msg.cl_ord_id, Some("CLIENT123".to_string()));
+		assert_eq!(msg.symbol, Some("AAPL".to_string()));
+		assert_eq!(msg.side, Some(Side::Buy));
+		assert_eq!(msg.order_qty, Some(100.0));
+	}
 
-    #[test]
-    fn test_additional_fields() {
-        let mut msg = FixMessage::default();
+	#[test]
+	fn test_additional_fields() {
+		let mut msg = FixMessage::default();
 
-        // Test setting and getting custom fields
-        msg.set_field(9999, "custom_value".to_string());
-        msg.set_field(8888, "another_value".to_string());
+		// Test setting and getting custom fields
+		msg.set_field(9999, "custom_value".to_string());
+		msg.set_field(8888, "another_value".to_string());
 
-        assert_eq!(msg.get_field(9999), Some(&"custom_value".to_string()));
-        assert_eq!(msg.get_field(8888), Some(&"another_value".to_string()));
-        assert_eq!(msg.get_field(7777), None);
+		assert_eq!(msg.get_field(9999), Some(&"custom_value".to_string()));
+		assert_eq!(msg.get_field(8888), Some(&"another_value".to_string()));
+		assert_eq!(msg.get_field(7777), None);
 
-        // Test overwriting a field
-        msg.set_field(9999, "updated_value".to_string());
-        assert_eq!(msg.get_field(9999), Some(&"updated_value".to_string()));
-    }
+		// Test overwriting a field
+		msg.set_field(9999, "updated_value".to_string());
+		assert_eq!(msg.get_field(9999), Some(&"updated_value".to_string()));
+	}
 
-    #[test]
-    fn test_is_valid() {
-        // Valid message
-        let valid_msg = FixMessage::new(
-            MsgType::Heartbeat,
-            "SENDER".to_string(),
-            "TARGET".to_string(),
-            1,
-            "20241201-12:00:00.000".to_string(),
-        );
-        assert!(valid_msg.is_valid());
+	#[test]
+	fn test_is_valid() {
+		// Valid message
+		let valid_msg = FixMessage::new(
+			MsgType::Heartbeat,
+			"SENDER".to_string(),
+			"TARGET".to_string(),
+			1,
+			"20241201-12:00:00.000".to_string(),
+		);
+		assert!(valid_msg.is_valid());
 
-        // Invalid message - empty sender
-        let invalid_msg = FixMessage::new(
-            MsgType::Heartbeat,
-            "".to_string(), // Empty sender
-            "TARGET".to_string(),
-            1,
-            "20241201-12:00:00.000".to_string(),
-        );
-        assert!(!invalid_msg.is_valid());
+		// Invalid message - empty sender
+		let invalid_msg = FixMessage::new(
+			MsgType::Heartbeat,
+			"".to_string(), // Empty sender
+			"TARGET".to_string(),
+			1,
+			"20241201-12:00:00.000".to_string(),
+		);
+		assert!(!invalid_msg.is_valid());
 
-        // Invalid message - empty target
-        let invalid_msg2 = FixMessage::new(
-            MsgType::Heartbeat,
-            "SENDER".to_string(),
-            "".to_string(), // Empty target
-            1,
-            "20241201-12:00:00.000".to_string(),
-        );
-        assert!(!invalid_msg2.is_valid());
+		// Invalid message - empty target
+		let invalid_msg2 = FixMessage::new(
+			MsgType::Heartbeat,
+			"SENDER".to_string(),
+			"".to_string(), // Empty target
+			1,
+			"20241201-12:00:00.000".to_string(),
+		);
+		assert!(!invalid_msg2.is_valid());
 
-        // Invalid message - empty sending time
-        let invalid_msg3 = FixMessage::new(
-            MsgType::Heartbeat,
-            "SENDER".to_string(),
-            "TARGET".to_string(),
-            1,
-            "".to_string(), // Empty sending time
-        );
-        assert!(!invalid_msg3.is_valid());
-    }
+		// Invalid message - empty sending time
+		let invalid_msg3 = FixMessage::new(
+			MsgType::Heartbeat,
+			"SENDER".to_string(),
+			"TARGET".to_string(),
+			1,
+			"".to_string(), // Empty sending time
+		);
+		assert!(!invalid_msg3.is_valid());
+	}
 
-    #[test]
-    fn test_message_equality() {
-        let msg1 = FixMessage::new(
-            MsgType::Heartbeat,
-            "SENDER".to_string(),
-            "TARGET".to_string(),
-            1,
-            "20241201-12:00:00.000".to_string(),
-        );
+	#[test]
+	fn test_message_equality() {
+		let msg1 = FixMessage::new(
+			MsgType::Heartbeat,
+			"SENDER".to_string(),
+			"TARGET".to_string(),
+			1,
+			"20241201-12:00:00.000".to_string(),
+		);
 
-        let msg2 = FixMessage::new(
-            MsgType::Heartbeat,
-            "SENDER".to_string(),
-            "TARGET".to_string(),
-            1,
-            "20241201-12:00:00.000".to_string(),
-        );
+		let msg2 = FixMessage::new(
+			MsgType::Heartbeat,
+			"SENDER".to_string(),
+			"TARGET".to_string(),
+			1,
+			"20241201-12:00:00.000".to_string(),
+		);
 
-        let msg3 = FixMessage::new(
-            MsgType::TestRequest, // Different message type
-            "SENDER".to_string(),
-            "TARGET".to_string(),
-            1,
-            "20241201-12:00:00.000".to_string(),
-        );
+		let msg3 = FixMessage::new(
+			MsgType::TestRequest, // Different message type
+			"SENDER".to_string(),
+			"TARGET".to_string(),
+			1,
+			"20241201-12:00:00.000".to_string(),
+		);
 
-        assert_eq!(msg1, msg2);
-        assert_ne!(msg1, msg3);
-    }
+		assert_eq!(msg1, msg2);
+		assert_ne!(msg1, msg3);
+	}
 
-    #[test]
-    fn test_message_cloning() {
-        let original = FixMessage::default();
-        let cloned = original.clone();
+	#[test]
+	fn test_message_cloning() {
+		let original = FixMessage::default();
+		let cloned = original.clone();
 
-        assert_eq!(original, cloned);
-        // Ensure they are separate instances
-        assert_eq!(original.cl_ord_id, cloned.cl_ord_id);
-        assert_eq!(original.symbol, cloned.symbol);
-    }
+		assert_eq!(original, cloned);
+		// Ensure they are separate instances
+		assert_eq!(original.cl_ord_id, cloned.cl_ord_id);
+		assert_eq!(original.symbol, cloned.symbol);
+	}
 }
 
 #[cfg(test)]
 mod integration_tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn test_new_order_single_workflow() {
-        // Create a New Order Single message
-        let mut new_order = FixMessage::new(
-            MsgType::NewOrderSingle,
-            "CLIENT".to_string(),
-            "BROKER".to_string(),
-            1,
-            "20241201-12:00:00.000".to_string(),
-        );
+	#[test]
+	fn test_new_order_single_workflow() {
+		// Create a New Order Single message
+		let mut new_order = FixMessage::new(
+			MsgType::NewOrderSingle,
+			"CLIENT".to_string(),
+			"BROKER".to_string(),
+			1,
+			"20241201-12:00:00.000".to_string(),
+		);
 
-        // Set order fields
-        new_order.cl_ord_id = Some("ORDER123".to_string());
-        new_order.symbol = Some("MSFT".to_string());
-        new_order.side = Some(Side::Buy);
-        new_order.order_qty = Some(100.0);
-        new_order.ord_type = Some("2".to_string()); // Limit order
-        new_order.price = Some(100.50);
-        new_order.time_in_force = Some("0".to_string()); // Day
+		// Set order fields
+		new_order.cl_ord_id = Some("ORDER123".to_string());
+		new_order.symbol = Some("MSFT".to_string());
+		new_order.side = Some(Side::Buy);
+		new_order.order_qty = Some(100.0);
+		new_order.ord_type = Some("2".to_string()); // Limit order
+		new_order.price = Some(100.50);
+		new_order.time_in_force = Some("0".to_string()); // Day
 
-        assert!(new_order.is_valid());
-        assert_eq!(new_order.msg_type, MsgType::NewOrderSingle);
-        assert_eq!(new_order.cl_ord_id, Some("ORDER123".to_string()));
-        assert_eq!(new_order.symbol, Some("MSFT".to_string()));
-        assert_eq!(new_order.side, Some(Side::Buy));
-    }
+		assert!(new_order.is_valid());
+		assert_eq!(new_order.msg_type, MsgType::NewOrderSingle);
+		assert_eq!(new_order.cl_ord_id, Some("ORDER123".to_string()));
+		assert_eq!(new_order.symbol, Some("MSFT".to_string()));
+		assert_eq!(new_order.side, Some(Side::Buy));
+	}
 
-    #[test]
-    fn test_execution_report_workflow() {
-        // Create an Execution Report in response to the order
-        let mut exec_report = FixMessage::new(
-            MsgType::ExecutionReport,
-            "BROKER".to_string(),
-            "CLIENT".to_string(),
-            1,
-            "20241201-12:00:01.000".to_string(),
-        );
+	#[test]
+	fn test_execution_report_workflow() {
+		// Create an Execution Report in response to the order
+		let mut exec_report = FixMessage::new(
+			MsgType::ExecutionReport,
+			"BROKER".to_string(),
+			"CLIENT".to_string(),
+			1,
+			"20241201-12:00:01.000".to_string(),
+		);
 
-        // Set execution fields
-        exec_report.cl_ord_id = Some("ORDER123".to_string());
-        exec_report.order_id = Some("BROKER123".to_string());
-        exec_report.exec_id = Some("EXEC456".to_string());
-        exec_report.exec_type = Some("0".to_string()); // New
-        exec_report.ord_status = Some(OrdStatus::New);
-        exec_report.symbol = Some("MSFT".to_string());
-        exec_report.side = Some(Side::Buy);
-        exec_report.order_qty = Some(100.0);
-        exec_report.leaves_qty = Some(100.0);
-        exec_report.cum_qty = Some(0.0);
+		// Set execution fields
+		exec_report.cl_ord_id = Some("ORDER123".to_string());
+		exec_report.order_id = Some("BROKER123".to_string());
+		exec_report.exec_id = Some("EXEC456".to_string());
+		exec_report.exec_type = Some("0".to_string()); // New
+		exec_report.ord_status = Some(OrdStatus::New);
+		exec_report.symbol = Some("MSFT".to_string());
+		exec_report.side = Some(Side::Buy);
+		exec_report.order_qty = Some(100.0);
+		exec_report.leaves_qty = Some(100.0);
+		exec_report.cum_qty = Some(0.0);
 
-        assert!(exec_report.is_valid());
-        assert_eq!(exec_report.msg_type, MsgType::ExecutionReport);
-        assert_eq!(exec_report.ord_status, Some(OrdStatus::New));
-    }
+		assert!(exec_report.is_valid());
+		assert_eq!(exec_report.msg_type, MsgType::ExecutionReport);
+		assert_eq!(exec_report.ord_status, Some(OrdStatus::New));
+	}
 
-    #[test]
-    fn test_fill_execution_report() {
-        // Create a fill execution report
-        let mut fill_report = FixMessage::new(
-            MsgType::ExecutionReport,
-            "BROKER".to_string(),
-            "CLIENT".to_string(),
-            2,
-            "20241201-12:00:02.000".to_string(),
-        );
+	#[test]
+	fn test_fill_execution_report() {
+		// Create a fill execution report
+		let mut fill_report = FixMessage::new(
+			MsgType::ExecutionReport,
+			"BROKER".to_string(),
+			"CLIENT".to_string(),
+			2,
+			"20241201-12:00:02.000".to_string(),
+		);
 
-        fill_report.cl_ord_id = Some("ORDER123".to_string());
-        fill_report.order_id = Some("BROKER123".to_string());
-        fill_report.exec_id = Some("EXEC789".to_string());
-        fill_report.exec_type = Some("F".to_string()); // Fill
-        fill_report.ord_status = Some(OrdStatus::Filled);
-        fill_report.symbol = Some("MSFT".to_string());
-        fill_report.side = Some(Side::Buy);
-        fill_report.order_qty = Some(100.0);
-        fill_report.last_qty = Some(100.0);
-        fill_report.last_px = Some(100.25);
-        fill_report.leaves_qty = Some(0.0);
-        fill_report.cum_qty = Some(100.0);
-        fill_report.avg_px = Some(100.25);
+		fill_report.cl_ord_id = Some("ORDER123".to_string());
+		fill_report.order_id = Some("BROKER123".to_string());
+		fill_report.exec_id = Some("EXEC789".to_string());
+		fill_report.exec_type = Some("F".to_string()); // Fill
+		fill_report.ord_status = Some(OrdStatus::Filled);
+		fill_report.symbol = Some("MSFT".to_string());
+		fill_report.side = Some(Side::Buy);
+		fill_report.order_qty = Some(100.0);
+		fill_report.last_qty = Some(100.0);
+		fill_report.last_px = Some(100.25);
+		fill_report.leaves_qty = Some(0.0);
+		fill_report.cum_qty = Some(100.0);
+		fill_report.avg_px = Some(100.25);
 
-        assert!(fill_report.is_valid());
-        assert_eq!(fill_report.ord_status, Some(OrdStatus::Filled));
-        assert_eq!(fill_report.leaves_qty, Some(0.0));
-        assert_eq!(fill_report.cum_qty, Some(100.0));
-    }
+		assert!(fill_report.is_valid());
+		assert_eq!(fill_report.ord_status, Some(OrdStatus::Filled));
+		assert_eq!(fill_report.leaves_qty, Some(0.0));
+		assert_eq!(fill_report.cum_qty, Some(100.0));
+	}
 
-    #[test]
-    fn test_heartbeat_message() {
-        let heartbeat = FixMessage::new(
-            MsgType::Heartbeat,
-            "CLIENT".to_string(),
-            "BROKER".to_string(),
-            10,
-            "20241201-12:05:00.000".to_string(),
-        );
+	#[test]
+	fn test_heartbeat_message() {
+		let heartbeat = FixMessage::new(
+			MsgType::Heartbeat,
+			"CLIENT".to_string(),
+			"BROKER".to_string(),
+			10,
+			"20241201-12:05:00.000".to_string(),
+		);
 
-        assert!(heartbeat.is_valid());
-        assert_eq!(heartbeat.msg_type, MsgType::Heartbeat);
-        assert_eq!(heartbeat.msg_seq_num, 10);
-    }
+		assert!(heartbeat.is_valid());
+		assert_eq!(heartbeat.msg_type, MsgType::Heartbeat);
+		assert_eq!(heartbeat.msg_seq_num, 10);
+	}
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8,490 +8,465 @@ use std::str::FromStr;
 
 #[cfg(test)]
 mod trading_workflow_tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn test_complete_order_lifecycle() {
-        // 1. Client sends New Order Single
-        let mut new_order = FixMessage::new(
-            MsgType::NewOrderSingle,
-            "CLIENT_TRADER".to_string(),
-            "PRIME_BROKER".to_string(),
-            1,
-            "20241201-09:30:00.000".to_string(),
-        );
+	#[test]
+	fn test_complete_order_lifecycle() {
+		// 1. Client sends New Order Single
+		let mut new_order = FixMessage::new(
+			MsgType::NewOrderSingle,
+			"CLIENT_TRADER".to_string(),
+			"PRIME_BROKER".to_string(),
+			1,
+			"20241201-09:30:00.000".to_string(),
+		);
 
-        new_order.cl_ord_id = Some("CLIENT_ORD_001".to_string());
-        new_order.symbol = Some("AAPL".to_string());
-        new_order.side = Some(Side::Buy);
-        new_order.order_qty = Some(1000.0);
-        new_order.ord_type = Some("2".to_string()); // Limit order
-        new_order.price = Some(150.25);
-        new_order.time_in_force = Some("0".to_string()); // Day order
+		new_order.cl_ord_id = Some("CLIENT_ORD_001".to_string());
+		new_order.symbol = Some("AAPL".to_string());
+		new_order.side = Some(Side::Buy);
+		new_order.order_qty = Some(1000.0);
+		new_order.ord_type = Some("2".to_string()); // Limit order
+		new_order.price = Some(150.25);
+		new_order.time_in_force = Some("0".to_string()); // Day order
 
-        assert!(new_order.is_valid());
-        assert_eq!(new_order.msg_type, MsgType::NewOrderSingle);
+		assert!(new_order.is_valid());
+		assert_eq!(new_order.msg_type, MsgType::NewOrderSingle);
 
-        // 2. Broker responds with Execution Report (New)
-        let mut exec_new = FixMessage::new(
-            MsgType::ExecutionReport,
-            "PRIME_BROKER".to_string(),
-            "CLIENT_TRADER".to_string(),
-            1,
-            "20241201-09:30:00.100".to_string(),
-        );
+		// 2. Broker responds with Execution Report (New)
+		let mut exec_new = FixMessage::new(
+			MsgType::ExecutionReport,
+			"PRIME_BROKER".to_string(),
+			"CLIENT_TRADER".to_string(),
+			1,
+			"20241201-09:30:00.100".to_string(),
+		);
 
-        exec_new.cl_ord_id = Some("CLIENT_ORD_001".to_string());
-        exec_new.order_id = Some("BROKER_ORD_12345".to_string());
-        exec_new.exec_id = Some("EXEC_001".to_string());
-        exec_new.exec_type = Some("0".to_string()); // New
-        exec_new.ord_status = Some(OrdStatus::New);
-        exec_new.symbol = Some("AAPL".to_string());
-        exec_new.side = Some(Side::Buy);
-        exec_new.order_qty = Some(1000.0);
-        exec_new.price = Some(150.25);
-        exec_new.leaves_qty = Some(1000.0);
-        exec_new.cum_qty = Some(0.0);
+		exec_new.cl_ord_id = Some("CLIENT_ORD_001".to_string());
+		exec_new.order_id = Some("BROKER_ORD_12345".to_string());
+		exec_new.exec_id = Some("EXEC_001".to_string());
+		exec_new.exec_type = Some("0".to_string()); // New
+		exec_new.ord_status = Some(OrdStatus::New);
+		exec_new.symbol = Some("AAPL".to_string());
+		exec_new.side = Some(Side::Buy);
+		exec_new.order_qty = Some(1000.0);
+		exec_new.price = Some(150.25);
+		exec_new.leaves_qty = Some(1000.0);
+		exec_new.cum_qty = Some(0.0);
 
-        assert_eq!(exec_new.ord_status, Some(OrdStatus::New));
-        assert_eq!(exec_new.leaves_qty, Some(1000.0));
+		assert_eq!(exec_new.ord_status, Some(OrdStatus::New));
+		assert_eq!(exec_new.leaves_qty, Some(1000.0));
 
-        // 3. Partial fill occurs
-        let mut exec_partial = FixMessage::new(
-            MsgType::ExecutionReport,
-            "PRIME_BROKER".to_string(),
-            "CLIENT_TRADER".to_string(),
-            2,
-            "20241201-09:30:15.250".to_string(),
-        );
+		// 3. Partial fill occurs
+		let mut exec_partial = FixMessage::new(
+			MsgType::ExecutionReport,
+			"PRIME_BROKER".to_string(),
+			"CLIENT_TRADER".to_string(),
+			2,
+			"20241201-09:30:15.250".to_string(),
+		);
 
-        exec_partial.cl_ord_id = Some("CLIENT_ORD_001".to_string());
-        exec_partial.order_id = Some("BROKER_ORD_12345".to_string());
-        exec_partial.exec_id = Some("EXEC_002".to_string());
-        exec_partial.exec_type = Some("F".to_string()); // Trade
-        exec_partial.ord_status = Some(OrdStatus::PartiallyFilled);
-        exec_partial.symbol = Some("AAPL".to_string());
-        exec_partial.side = Some(Side::Buy);
-        exec_partial.order_qty = Some(1000.0);
-        exec_partial.last_qty = Some(400.0);
-        exec_partial.last_px = Some(150.20);
-        exec_partial.leaves_qty = Some(600.0);
-        exec_partial.cum_qty = Some(400.0);
-        exec_partial.avg_px = Some(150.20);
+		exec_partial.cl_ord_id = Some("CLIENT_ORD_001".to_string());
+		exec_partial.order_id = Some("BROKER_ORD_12345".to_string());
+		exec_partial.exec_id = Some("EXEC_002".to_string());
+		exec_partial.exec_type = Some("F".to_string()); // Trade
+		exec_partial.ord_status = Some(OrdStatus::PartiallyFilled);
+		exec_partial.symbol = Some("AAPL".to_string());
+		exec_partial.side = Some(Side::Buy);
+		exec_partial.order_qty = Some(1000.0);
+		exec_partial.last_qty = Some(400.0);
+		exec_partial.last_px = Some(150.20);
+		exec_partial.leaves_qty = Some(600.0);
+		exec_partial.cum_qty = Some(400.0);
+		exec_partial.avg_px = Some(150.20);
 
-        assert_eq!(exec_partial.ord_status, Some(OrdStatus::PartiallyFilled));
-        assert_eq!(exec_partial.cum_qty, Some(400.0));
-        assert_eq!(exec_partial.leaves_qty, Some(600.0));
+		assert_eq!(exec_partial.ord_status, Some(OrdStatus::PartiallyFilled));
+		assert_eq!(exec_partial.cum_qty, Some(400.0));
+		assert_eq!(exec_partial.leaves_qty, Some(600.0));
 
-        // 4. Final fill completes the order
-        let mut exec_filled = FixMessage::new(
-            MsgType::ExecutionReport,
-            "PRIME_BROKER".to_string(),
-            "CLIENT_TRADER".to_string(),
-            3,
-            "20241201-09:30:45.500".to_string(),
-        );
+		// 4. Final fill completes the order
+		let mut exec_filled = FixMessage::new(
+			MsgType::ExecutionReport,
+			"PRIME_BROKER".to_string(),
+			"CLIENT_TRADER".to_string(),
+			3,
+			"20241201-09:30:45.500".to_string(),
+		);
 
-        exec_filled.cl_ord_id = Some("CLIENT_ORD_001".to_string());
-        exec_filled.order_id = Some("BROKER_ORD_12345".to_string());
-        exec_filled.exec_id = Some("EXEC_003".to_string());
-        exec_filled.exec_type = Some("F".to_string()); // Trade
-        exec_filled.ord_status = Some(OrdStatus::Filled);
-        exec_filled.symbol = Some("AAPL".to_string());
-        exec_filled.side = Some(Side::Buy);
-        exec_filled.order_qty = Some(1000.0);
-        exec_filled.last_qty = Some(600.0);
-        exec_filled.last_px = Some(150.18);
-        exec_filled.leaves_qty = Some(0.0);
-        exec_filled.cum_qty = Some(1000.0);
-        exec_filled.avg_px = Some(150.19); // Weighted average
+		exec_filled.cl_ord_id = Some("CLIENT_ORD_001".to_string());
+		exec_filled.order_id = Some("BROKER_ORD_12345".to_string());
+		exec_filled.exec_id = Some("EXEC_003".to_string());
+		exec_filled.exec_type = Some("F".to_string()); // Trade
+		exec_filled.ord_status = Some(OrdStatus::Filled);
+		exec_filled.symbol = Some("AAPL".to_string());
+		exec_filled.side = Some(Side::Buy);
+		exec_filled.order_qty = Some(1000.0);
+		exec_filled.last_qty = Some(600.0);
+		exec_filled.last_px = Some(150.18);
+		exec_filled.leaves_qty = Some(0.0);
+		exec_filled.cum_qty = Some(1000.0);
+		exec_filled.avg_px = Some(150.19); // Weighted average
 
-        assert_eq!(exec_filled.ord_status, Some(OrdStatus::Filled));
-        assert_eq!(exec_filled.cum_qty, Some(1000.0));
-        assert_eq!(exec_filled.leaves_qty, Some(0.0));
-    }
+		assert_eq!(exec_filled.ord_status, Some(OrdStatus::Filled));
+		assert_eq!(exec_filled.cum_qty, Some(1000.0));
+		assert_eq!(exec_filled.leaves_qty, Some(0.0));
+	}
 
-    #[test]
-    fn test_order_cancel_workflow() {
-        // 1. Original order
-        let mut original_order = FixMessage::new(
-            MsgType::NewOrderSingle,
-            "HEDGE_FUND".to_string(),
-            "ECN_BROKER".to_string(),
-            10,
-            "20241201-10:15:00.000".to_string(),
-        );
+	#[test]
+	fn test_order_cancel_workflow() {
+		// 1. Original order
+		let mut original_order = FixMessage::new(
+			MsgType::NewOrderSingle,
+			"HEDGE_FUND".to_string(),
+			"ECN_BROKER".to_string(),
+			10,
+			"20241201-10:15:00.000".to_string(),
+		);
 
-        original_order.cl_ord_id = Some("HF_ORDER_500".to_string());
-        original_order.symbol = Some("TSLA".to_string());
-        original_order.side = Some(Side::Sell);
-        original_order.order_qty = Some(2000.0);
-        original_order.ord_type = Some("2".to_string()); // Limit
-        original_order.price = Some(245.75);
+		original_order.cl_ord_id = Some("HF_ORDER_500".to_string());
+		original_order.symbol = Some("TSLA".to_string());
+		original_order.side = Some(Side::Sell);
+		original_order.order_qty = Some(2000.0);
+		original_order.ord_type = Some("2".to_string()); // Limit
+		original_order.price = Some(245.75);
 
-        // 2. Order acknowledged
-        let mut ack_report = FixMessage::new(
-            MsgType::ExecutionReport,
-            "ECN_BROKER".to_string(),
-            "HEDGE_FUND".to_string(),
-            10,
-            "20241201-10:15:00.050".to_string(),
-        );
+		// 2. Order acknowledged
+		let mut ack_report = FixMessage::new(
+			MsgType::ExecutionReport,
+			"ECN_BROKER".to_string(),
+			"HEDGE_FUND".to_string(),
+			10,
+			"20241201-10:15:00.050".to_string(),
+		);
 
-        ack_report.cl_ord_id = Some("HF_ORDER_500".to_string());
-        ack_report.order_id = Some("ECN_12345".to_string());
-        ack_report.exec_id = Some("ACK_001".to_string());
-        ack_report.exec_type = Some("0".to_string()); // New
-        ack_report.ord_status = Some(OrdStatus::New);
-        ack_report.leaves_qty = Some(2000.0);
-        ack_report.cum_qty = Some(0.0);
+		ack_report.cl_ord_id = Some("HF_ORDER_500".to_string());
+		ack_report.order_id = Some("ECN_12345".to_string());
+		ack_report.exec_id = Some("ACK_001".to_string());
+		ack_report.exec_type = Some("0".to_string()); // New
+		ack_report.ord_status = Some(OrdStatus::New);
+		ack_report.leaves_qty = Some(2000.0);
+		ack_report.cum_qty = Some(0.0);
 
-        // 3. Client decides to cancel
-        let mut cancel_request = FixMessage::new(
-            MsgType::OrderCancelRequest,
-            "HEDGE_FUND".to_string(),
-            "ECN_BROKER".to_string(),
-            11,
-            "20241201-10:16:30.000".to_string(),
-        );
+		// 3. Client decides to cancel
+		let mut cancel_request = FixMessage::new(
+			MsgType::OrderCancelRequest,
+			"HEDGE_FUND".to_string(),
+			"ECN_BROKER".to_string(),
+			11,
+			"20241201-10:16:30.000".to_string(),
+		);
 
-        cancel_request.cl_ord_id = Some("HF_ORDER_500".to_string());
-        cancel_request.order_id = Some("ECN_12345".to_string());
-        cancel_request.symbol = Some("TSLA".to_string());
-        cancel_request.side = Some(Side::Sell);
-        cancel_request.order_qty = Some(2000.0);
+		cancel_request.cl_ord_id = Some("HF_ORDER_500".to_string());
+		cancel_request.order_id = Some("ECN_12345".to_string());
+		cancel_request.symbol = Some("TSLA".to_string());
+		cancel_request.side = Some(Side::Sell);
+		cancel_request.order_qty = Some(2000.0);
 
-        // 4. Broker confirms cancellation
-        let mut cancel_report = FixMessage::new(
-            MsgType::ExecutionReport,
-            "ECN_BROKER".to_string(),
-            "HEDGE_FUND".to_string(),
-            11,
-            "20241201-10:16:30.100".to_string(),
-        );
+		// 4. Broker confirms cancellation
+		let mut cancel_report = FixMessage::new(
+			MsgType::ExecutionReport,
+			"ECN_BROKER".to_string(),
+			"HEDGE_FUND".to_string(),
+			11,
+			"20241201-10:16:30.100".to_string(),
+		);
 
-        cancel_report.cl_ord_id = Some("HF_ORDER_500".to_string());
-        cancel_report.order_id = Some("ECN_12345".to_string());
-        cancel_report.exec_id = Some("CANCEL_001".to_string());
-        cancel_report.exec_type = Some("4".to_string()); // Canceled
-        cancel_report.ord_status = Some(OrdStatus::Canceled);
-        cancel_report.symbol = Some("TSLA".to_string());
-        cancel_report.side = Some(Side::Sell);
-        cancel_report.order_qty = Some(2000.0);
-        cancel_report.leaves_qty = Some(0.0);
-        cancel_report.cum_qty = Some(0.0);
+		cancel_report.cl_ord_id = Some("HF_ORDER_500".to_string());
+		cancel_report.order_id = Some("ECN_12345".to_string());
+		cancel_report.exec_id = Some("CANCEL_001".to_string());
+		cancel_report.exec_type = Some("4".to_string()); // Canceled
+		cancel_report.ord_status = Some(OrdStatus::Canceled);
+		cancel_report.symbol = Some("TSLA".to_string());
+		cancel_report.side = Some(Side::Sell);
+		cancel_report.order_qty = Some(2000.0);
+		cancel_report.leaves_qty = Some(0.0);
+		cancel_report.cum_qty = Some(0.0);
 
-        assert_eq!(cancel_report.ord_status, Some(OrdStatus::Canceled));
-        assert_eq!(cancel_report.leaves_qty, Some(0.0));
-    }
+		assert_eq!(cancel_report.ord_status, Some(OrdStatus::Canceled));
+		assert_eq!(cancel_report.leaves_qty, Some(0.0));
+	}
 
-    #[test]
-    fn test_order_replace_workflow() {
-        // 1. Original order
-        let original_cl_ord_id = "PROP_TRADE_100";
-        let new_cl_ord_id = "PROP_TRADE_100_R1";
+	#[test]
+	fn test_order_replace_workflow() {
+		// 1. Original order
+		let original_cl_ord_id = "PROP_TRADE_100";
+		let new_cl_ord_id = "PROP_TRADE_100_R1";
 
-        // 2. Order replace request
-        let mut replace_request = FixMessage::new(
-            MsgType::OrderCancelReplaceRequest,
-            "PROP_DESK".to_string(),
-            "DARK_POOL".to_string(),
-            25,
-            "20241201-11:30:00.000".to_string(),
-        );
+		// 2. Order replace request
+		let mut replace_request = FixMessage::new(
+			MsgType::OrderCancelReplaceRequest,
+			"PROP_DESK".to_string(),
+			"DARK_POOL".to_string(),
+			25,
+			"20241201-11:30:00.000".to_string(),
+		);
 
-        replace_request.cl_ord_id = Some(new_cl_ord_id.to_string());
-        replace_request.order_id = Some("DARK_567890".to_string());
-        replace_request.symbol = Some("NVDA".to_string());
-        replace_request.side = Some(Side::Buy);
-        replace_request.order_qty = Some(1500.0); // Increased from 1000
-        replace_request.ord_type = Some("2".to_string());
-        replace_request.price = Some(520.50); // Increased price
-        // Add original client order ID in additional fields
-        replace_request.set_field(41, original_cl_ord_id.to_string()); // OrigClOrdID
+		replace_request.cl_ord_id = Some(new_cl_ord_id.to_string());
+		replace_request.order_id = Some("DARK_567890".to_string());
+		replace_request.symbol = Some("NVDA".to_string());
+		replace_request.side = Some(Side::Buy);
+		replace_request.order_qty = Some(1500.0); // Increased from 1000
+		replace_request.ord_type = Some("2".to_string());
+		replace_request.price = Some(520.50); // Increased price
+		// Add original client order ID in additional fields
+		replace_request.set_field(41, original_cl_ord_id.to_string()); // OrigClOrdID
 
-        // 3. Replace confirmation
-        let mut replace_report = FixMessage::new(
-            MsgType::ExecutionReport,
-            "DARK_POOL".to_string(),
-            "PROP_DESK".to_string(),
-            25,
-            "20241201-11:30:00.150".to_string(),
-        );
+		// 3. Replace confirmation
+		let mut replace_report = FixMessage::new(
+			MsgType::ExecutionReport,
+			"DARK_POOL".to_string(),
+			"PROP_DESK".to_string(),
+			25,
+			"20241201-11:30:00.150".to_string(),
+		);
 
-        replace_report.cl_ord_id = Some(new_cl_ord_id.to_string());
-        replace_report.order_id = Some("DARK_567890".to_string());
-        replace_report.exec_id = Some("REPLACE_001".to_string());
-        replace_report.exec_type = Some("5".to_string()); // Replace
-        replace_report.ord_status = Some(OrdStatus::Replaced);
-        replace_report.symbol = Some("NVDA".to_string());
-        replace_report.side = Some(Side::Buy);
-        replace_report.order_qty = Some(1500.0);
-        replace_report.price = Some(520.50);
-        replace_report.leaves_qty = Some(1500.0);
-        replace_report.cum_qty = Some(0.0);
+		replace_report.cl_ord_id = Some(new_cl_ord_id.to_string());
+		replace_report.order_id = Some("DARK_567890".to_string());
+		replace_report.exec_id = Some("REPLACE_001".to_string());
+		replace_report.exec_type = Some("5".to_string()); // Replace
+		replace_report.ord_status = Some(OrdStatus::Replaced);
+		replace_report.symbol = Some("NVDA".to_string());
+		replace_report.side = Some(Side::Buy);
+		replace_report.order_qty = Some(1500.0);
+		replace_report.price = Some(520.50);
+		replace_report.leaves_qty = Some(1500.0);
+		replace_report.cum_qty = Some(0.0);
 
-        assert_eq!(replace_report.ord_status, Some(OrdStatus::Replaced));
-        assert_eq!(replace_report.order_qty, Some(1500.0));
-        assert_eq!(replace_report.price, Some(520.50));
-        assert_eq!(
-            replace_request.get_field(41),
-            Some(&original_cl_ord_id.to_string())
-        );
-    }
+		assert_eq!(replace_report.ord_status, Some(OrdStatus::Replaced));
+		assert_eq!(replace_report.order_qty, Some(1500.0));
+		assert_eq!(replace_report.price, Some(520.50));
+		assert_eq!(replace_request.get_field(41), Some(&original_cl_ord_id.to_string()));
+	}
 
-    #[test]
-    fn test_heartbeat_sequence() {
-        let mut sequence_num = 100;
+	#[test]
+	fn test_heartbeat_sequence() {
+		let mut sequence_num = 100;
 
-        // Heartbeat from client to server
-        let client_heartbeat = FixMessage::new(
-            MsgType::Heartbeat,
-            "CLIENT_SYSTEM".to_string(),
-            "MARKET_DATA_PROVIDER".to_string(),
-            sequence_num,
-            "20241201-12:00:00.000".to_string(),
-        );
+		// Heartbeat from client to server
+		let client_heartbeat = FixMessage::new(
+			MsgType::Heartbeat,
+			"CLIENT_SYSTEM".to_string(),
+			"MARKET_DATA_PROVIDER".to_string(),
+			sequence_num,
+			"20241201-12:00:00.000".to_string(),
+		);
 
-        sequence_num += 1;
+		sequence_num += 1;
 
-        // Heartbeat response from server
-        let server_heartbeat = FixMessage::new(
-            MsgType::Heartbeat,
-            "MARKET_DATA_PROVIDER".to_string(),
-            "CLIENT_SYSTEM".to_string(),
-            sequence_num,
-            "20241201-12:00:00.100".to_string(),
-        );
+		// Heartbeat response from server
+		let server_heartbeat = FixMessage::new(
+			MsgType::Heartbeat,
+			"MARKET_DATA_PROVIDER".to_string(),
+			"CLIENT_SYSTEM".to_string(),
+			sequence_num,
+			"20241201-12:00:00.100".to_string(),
+		);
 
-        assert_eq!(client_heartbeat.msg_type, MsgType::Heartbeat);
-        assert_eq!(server_heartbeat.msg_type, MsgType::Heartbeat);
-        assert!(client_heartbeat.is_valid());
-        assert!(server_heartbeat.is_valid());
-    }
+		assert_eq!(client_heartbeat.msg_type, MsgType::Heartbeat);
+		assert_eq!(server_heartbeat.msg_type, MsgType::Heartbeat);
+		assert!(client_heartbeat.is_valid());
+		assert!(server_heartbeat.is_valid());
+	}
 
-    #[test]
-    fn test_market_data_request_workflow() {
-        // Market data subscription request
-        let mut md_request = FixMessage::new(
-            MsgType::MarketDataRequest,
-            "TRADING_ENGINE".to_string(),
-            "MARKET_DATA_SERVICE".to_string(),
-            50,
-            "20241201-13:15:00.000".to_string(),
-        );
+	#[test]
+	fn test_market_data_request_workflow() {
+		// Market data subscription request
+		let mut md_request = FixMessage::new(
+			MsgType::MarketDataRequest,
+			"TRADING_ENGINE".to_string(),
+			"MARKET_DATA_SERVICE".to_string(),
+			50,
+			"20241201-13:15:00.000".to_string(),
+		);
 
-        md_request.symbol = Some("SPY".to_string());
-        md_request.set_field(262, "SPY_L1_FEED".to_string()); // MDReqID
-        md_request.set_field(263, "1".to_string()); // SubscriptionRequestType (Snapshot + Updates)
-        md_request.set_field(264, "1".to_string()); // MarketDepth (Top of book)
+		md_request.symbol = Some("SPY".to_string());
+		md_request.set_field(262, "SPY_L1_FEED".to_string()); // MDReqID
+		md_request.set_field(263, "1".to_string()); // SubscriptionRequestType (Snapshot + Updates)
+		md_request.set_field(264, "1".to_string()); // MarketDepth (Top of book)
 
-        // Market data snapshot response
-        let mut md_snapshot = FixMessage::new(
-            MsgType::MarketDataSnapshot,
-            "MARKET_DATA_SERVICE".to_string(),
-            "TRADING_ENGINE".to_string(),
-            50,
-            "20241201-13:15:00.050".to_string(),
-        );
+		// Market data snapshot response
+		let mut md_snapshot = FixMessage::new(
+			MsgType::MarketDataSnapshot,
+			"MARKET_DATA_SERVICE".to_string(),
+			"TRADING_ENGINE".to_string(),
+			50,
+			"20241201-13:15:00.050".to_string(),
+		);
 
-        md_snapshot.symbol = Some("SPY".to_string());
-        md_snapshot.set_field(262, "SPY_L1_FEED".to_string()); // MDReqID
-        md_snapshot.set_field(268, "2".to_string()); // NoMDEntries (Bid and Ask)
-        md_snapshot.set_field(269, "0".to_string()); // MDEntryType (Bid)
-        md_snapshot.set_field(270, "445.25".to_string()); // MDEntryPx (Bid price)
-        md_snapshot.set_field(271, "1000".to_string()); // MDEntrySize (Bid size)
+		md_snapshot.symbol = Some("SPY".to_string());
+		md_snapshot.set_field(262, "SPY_L1_FEED".to_string()); // MDReqID
+		md_snapshot.set_field(268, "2".to_string()); // NoMDEntries (Bid and Ask)
+		md_snapshot.set_field(269, "0".to_string()); // MDEntryType (Bid)
+		md_snapshot.set_field(270, "445.25".to_string()); // MDEntryPx (Bid price)
+		md_snapshot.set_field(271, "1000".to_string()); // MDEntrySize (Bid size)
 
-        assert_eq!(md_request.msg_type, MsgType::MarketDataRequest);
-        assert_eq!(md_snapshot.msg_type, MsgType::MarketDataSnapshot);
-        assert_eq!(md_request.get_field(262), Some(&"SPY_L1_FEED".to_string()));
-        assert_eq!(md_snapshot.get_field(270), Some(&"445.25".to_string()));
-    }
+		assert_eq!(md_request.msg_type, MsgType::MarketDataRequest);
+		assert_eq!(md_snapshot.msg_type, MsgType::MarketDataSnapshot);
+		assert_eq!(md_request.get_field(262), Some(&"SPY_L1_FEED".to_string()));
+		assert_eq!(md_snapshot.get_field(270), Some(&"445.25".to_string()));
+	}
 
-    #[test]
-    fn test_reject_message() {
-        // Invalid order that gets rejected
-        let mut reject_msg = FixMessage::new(
-            MsgType::Reject,
-            "EXCHANGE".to_string(),
-            "BAD_CLIENT".to_string(),
-            999,
-            "20241201-14:00:00.000".to_string(),
-        );
+	#[test]
+	fn test_reject_message() {
+		// Invalid order that gets rejected
+		let mut reject_msg = FixMessage::new(
+			MsgType::Reject,
+			"EXCHANGE".to_string(),
+			"BAD_CLIENT".to_string(),
+			999,
+			"20241201-14:00:00.000".to_string(),
+		);
 
-        reject_msg.text = Some("Invalid symbol: INVALID_SYM".to_string());
-        reject_msg.set_field(45, "1000".to_string()); // RefSeqNum - sequence number being rejected
-        reject_msg.set_field(371, "35".to_string()); // RefTagID - tag 35 (MsgType) has issue
-        reject_msg.set_field(372, "5".to_string()); // RefMsgType - value that was rejected
-        reject_msg.set_field(373, "2".to_string()); // SessionRejectReason - invalid tag number
+		reject_msg.text = Some("Invalid symbol: INVALID_SYM".to_string());
+		reject_msg.set_field(45, "1000".to_string()); // RefSeqNum - sequence number being rejected
+		reject_msg.set_field(371, "35".to_string()); // RefTagID - tag 35 (MsgType) has issue
+		reject_msg.set_field(372, "5".to_string()); // RefMsgType - value that was rejected
+		reject_msg.set_field(373, "2".to_string()); // SessionRejectReason - invalid tag number
 
-        assert_eq!(reject_msg.msg_type, MsgType::Reject);
-        assert_eq!(
-            reject_msg.text,
-            Some("Invalid symbol: INVALID_SYM".to_string())
-        );
-        assert_eq!(reject_msg.get_field(45), Some(&"1000".to_string()));
-    }
+		assert_eq!(reject_msg.msg_type, MsgType::Reject);
+		assert_eq!(reject_msg.text, Some("Invalid symbol: INVALID_SYM".to_string()));
+		assert_eq!(reject_msg.get_field(45), Some(&"1000".to_string()));
+	}
 
-    #[test]
-    fn test_security_definition_workflow() {
-        // Security definition request
-        let mut sec_def_request = FixMessage::new(
-            MsgType::SecurityDefinitionRequest,
-            "RISK_SYSTEM".to_string(),
-            "REFERENCE_DATA".to_string(),
-            200,
-            "20241201-08:00:00.000".to_string(),
-        );
+	#[test]
+	fn test_security_definition_workflow() {
+		// Security definition request
+		let mut sec_def_request = FixMessage::new(
+			MsgType::SecurityDefinitionRequest,
+			"RISK_SYSTEM".to_string(),
+			"REFERENCE_DATA".to_string(),
+			200,
+			"20241201-08:00:00.000".to_string(),
+		);
 
-        sec_def_request.symbol = Some("MSFT".to_string());
-        sec_def_request.set_field(320, "SEC_DEF_REQ_001".to_string()); // SecurityReqID
-        sec_def_request.set_field(321, "1".to_string()); // SecurityRequestType
+		sec_def_request.symbol = Some("MSFT".to_string());
+		sec_def_request.set_field(320, "SEC_DEF_REQ_001".to_string()); // SecurityReqID
+		sec_def_request.set_field(321, "1".to_string()); // SecurityRequestType
 
-        // Security definition response
-        let mut sec_def_response = FixMessage::new(
-            MsgType::SecurityDefinition,
-            "REFERENCE_DATA".to_string(),
-            "RISK_SYSTEM".to_string(),
-            200,
-            "20241201-08:00:00.100".to_string(),
-        );
+		// Security definition response
+		let mut sec_def_response = FixMessage::new(
+			MsgType::SecurityDefinition,
+			"REFERENCE_DATA".to_string(),
+			"RISK_SYSTEM".to_string(),
+			200,
+			"20241201-08:00:00.100".to_string(),
+		);
 
-        sec_def_response.symbol = Some("MSFT".to_string());
-        sec_def_response.security_type = Some("CS".to_string()); // Common Stock
-        sec_def_response.set_field(320, "SEC_DEF_REQ_001".to_string()); // SecurityReqID
-        sec_def_response.set_field(323, "1".to_string()); // SecurityResponseType (Accept)
-        sec_def_response.set_field(107, "Microsoft Corporation".to_string()); // SecurityDesc
+		sec_def_response.symbol = Some("MSFT".to_string());
+		sec_def_response.security_type = Some("CS".to_string()); // Common Stock
+		sec_def_response.set_field(320, "SEC_DEF_REQ_001".to_string()); // SecurityReqID
+		sec_def_response.set_field(323, "1".to_string()); // SecurityResponseType (Accept)
+		sec_def_response.set_field(107, "Microsoft Corporation".to_string()); // SecurityDesc
 
-        assert_eq!(sec_def_request.msg_type, MsgType::SecurityDefinitionRequest);
-        assert_eq!(sec_def_response.msg_type, MsgType::SecurityDefinition);
-        assert_eq!(
-            sec_def_response.get_field(107),
-            Some(&"Microsoft Corporation".to_string())
-        );
-    }
+		assert_eq!(sec_def_request.msg_type, MsgType::SecurityDefinitionRequest);
+		assert_eq!(sec_def_response.msg_type, MsgType::SecurityDefinition);
+		assert_eq!(sec_def_response.get_field(107), Some(&"Microsoft Corporation".to_string()));
+	}
 }
 
 #[cfg(test)]
 mod message_parsing_tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn test_parse_real_fix_message() {
-        // Test parsing a real FIX message from https://robertwray.co.uk/blog/the-anatomy-of-a-fix-message
-        let fix_string = "8=FIX.4.2\x019=171\x0135=R\x0134=3257\x0149=COMP-PRICES\x0152=20180508-09:02:43.968\x0156=BANK-PRICES\x01131=Q-EURGBP-BUY-3357-636613669639680362\x01146=1\x0155=EUR/GBP\x0115=EUR\x0138=3357\x0140=C\x0154=1\x0164=20180508\x01167=FOR\x0110=150";
+	#[test]
+	fn test_parse_real_fix_message() {
+		// Test parsing a real FIX message from https://robertwray.co.uk/blog/the-anatomy-of-a-fix-message
+		let fix_string = "8=FIX.4.2\x019=171\x0135=R\x0134=3257\x0149=COMP-PRICES\x0152=20180508-09:02:43.968\x0156=BANK-PRICES\x01131=Q-EURGBP-BUY-3357-636613669639680362\x01146=1\x0155=EUR/GBP\x0115=EUR\x0138=3357\x0140=C\x0154=1\x0164=20180508\x01167=FOR\x0110=150";
 
-        let result = FixMessage::from_fix_string(fix_string);
+		let result = FixMessage::from_fix_string(fix_string);
 
-        assert!(
-            result.is_ok(),
-            "Failed to parse FIX message: {:?}",
-            result.err()
-        );
+		assert!(result.is_ok(), "Failed to parse FIX message: {:?}", result.err());
 
-        let message = result.unwrap();
+		let message = result.unwrap();
 
-        // Verify standard header fields
-        assert_eq!(message.begin_string, "FIX.4.2");
-        assert_eq!(message.body_length, 171);
-        assert_eq!(message.msg_type, MsgType::Other("R".to_string())); // Quote Request
-        assert_eq!(message.msg_seq_num, 3257);
-        assert_eq!(message.sender_comp_id, "COMP-PRICES");
-        assert_eq!(message.sending_time, "20180508-09:02:43.968");
-        assert_eq!(message.target_comp_id, "BANK-PRICES");
+		// Verify standard header fields
+		assert_eq!(message.begin_string, "FIX.4.2");
+		assert_eq!(message.body_length, 171);
+		assert_eq!(message.msg_type, MsgType::Other("R".to_string())); // Quote Request
+		assert_eq!(message.msg_seq_num, 3257);
+		assert_eq!(message.sender_comp_id, "COMP-PRICES");
+		assert_eq!(message.sending_time, "20180508-09:02:43.968");
+		assert_eq!(message.target_comp_id, "BANK-PRICES");
 
-        // Verify message-specific fields
-        assert_eq!(message.symbol, Some("EUR/GBP".to_string()));
-        assert_eq!(message.side, Some(Side::Buy));
-        assert_eq!(message.order_qty, Some(3357.0));
-        assert_eq!(message.security_type, Some("FOR".to_string()));
-        assert_eq!(message.checksum, "150");
+		// Verify message-specific fields
+		assert_eq!(message.symbol, Some("EUR/GBP".to_string()));
+		assert_eq!(message.side, Some(Side::Buy));
+		assert_eq!(message.order_qty, Some(3357.0));
+		assert_eq!(message.security_type, Some("FOR".to_string()));
+		assert_eq!(message.checksum, "150");
 
-        // Verify additional fields are captured
-        assert_eq!(
-            message.get_field(131),
-            Some(&"Q-EURGBP-BUY-3357-636613669639680362".to_string())
-        );
-        assert_eq!(message.get_field(146), Some(&"1".to_string()));
-        assert_eq!(message.get_field(15), Some(&"EUR".to_string()));
-        assert_eq!(message.get_field(64), Some(&"20180508".to_string()));
+		// Verify additional fields are captured
+		assert_eq!(message.get_field(131), Some(&"Q-EURGBP-BUY-3357-636613669639680362".to_string()));
+		assert_eq!(message.get_field(146), Some(&"1".to_string()));
+		assert_eq!(message.get_field(15), Some(&"EUR".to_string()));
+		assert_eq!(message.get_field(64), Some(&"20180508".to_string()));
 
-        // Verify the message is considered valid
-        assert!(message.is_valid());
-    }
+		// Verify the message is considered valid
+		assert!(message.is_valid());
+	}
 }
 
 mod error_handling_tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn test_invalid_message_validation() {
-        // Test various invalid message scenarios
-        let mut invalid_msg = FixMessage::default();
+	#[test]
+	fn test_invalid_message_validation() {
+		// Test various invalid message scenarios
+		let mut invalid_msg = FixMessage::default();
 
-        // Empty sender should make it invalid
-        invalid_msg.sender_comp_id = "".to_string();
-        assert!(!invalid_msg.is_valid());
+		// Empty sender should make it invalid
+		invalid_msg.sender_comp_id = "".to_string();
+		assert!(!invalid_msg.is_valid());
 
-        // Fix sender, but empty target
-        invalid_msg.sender_comp_id = "VALID_SENDER".to_string();
-        invalid_msg.target_comp_id = "".to_string();
-        assert!(!invalid_msg.is_valid());
+		// Fix sender, but empty target
+		invalid_msg.sender_comp_id = "VALID_SENDER".to_string();
+		invalid_msg.target_comp_id = "".to_string();
+		assert!(!invalid_msg.is_valid());
 
-        // Fix target, but empty sending time
-        invalid_msg.target_comp_id = "VALID_TARGET".to_string();
-        invalid_msg.sending_time = "".to_string();
-        assert!(!invalid_msg.is_valid());
+		// Fix target, but empty sending time
+		invalid_msg.target_comp_id = "VALID_TARGET".to_string();
+		invalid_msg.sending_time = "".to_string();
+		assert!(!invalid_msg.is_valid());
 
-        // Fix sending time - should now be valid
-        invalid_msg.sending_time = "20241201-12:00:00.000".to_string();
-        assert!(invalid_msg.is_valid());
-    }
+		// Fix sending time - should now be valid
+		invalid_msg.sending_time = "20241201-12:00:00.000".to_string();
+		assert!(invalid_msg.is_valid());
+	}
 
-    #[test]
-    fn test_enum_edge_cases() {
-        // Test Side enum edge cases
-        assert!(Side::from_str("").is_err());
-        assert!(Side::from_str("3").is_err());
-        assert!(Side::from_str("B").is_err());
-        assert!(Side::from_str("S").is_err());
+	#[test]
+	fn test_enum_edge_cases() {
+		// Test Side enum edge cases
+		assert!(Side::from_str("").is_err());
+		assert!(Side::from_str("3").is_err());
+		assert!(Side::from_str("B").is_err());
+		assert!(Side::from_str("S").is_err());
 
-        // Test OrdStatus enum edge cases
-        assert!(OrdStatus::from_str("").is_err());
-        assert!(OrdStatus::from_str("Z").is_err());
-        assert!(OrdStatus::from_str("99").is_err());
+		// Test OrdStatus enum edge cases
+		assert!(OrdStatus::from_str("").is_err());
+		assert!(OrdStatus::from_str("Z").is_err());
+		assert!(OrdStatus::from_str("99").is_err());
 
-        // Test MsgType with various inputs
-        assert_eq!(
-            MsgType::from_str("").unwrap(),
-            MsgType::Other("".to_string())
-        );
-        assert_eq!(
-            MsgType::from_str("CUSTOM").unwrap(),
-            MsgType::Other("CUSTOM".to_string())
-        );
-        assert_eq!(
-            MsgType::from_str("999").unwrap(),
-            MsgType::Other("999".to_string())
-        );
-    }
+		// Test MsgType with various inputs
+		assert_eq!(MsgType::from_str("").unwrap(), MsgType::Other("".to_string()));
+		assert_eq!(MsgType::from_str("CUSTOM").unwrap(), MsgType::Other("CUSTOM".to_string()));
+		assert_eq!(MsgType::from_str("999").unwrap(), MsgType::Other("999".to_string()));
+	}
 
-    #[test]
-    fn test_field_operations_edge_cases() {
-        let mut msg = FixMessage::default();
+	#[test]
+	fn test_field_operations_edge_cases() {
+		let mut msg = FixMessage::default();
 
-        // Test getting non-existent field
-        assert_eq!(msg.get_field(99999), None);
+		// Test getting non-existent field
+		assert_eq!(msg.get_field(99999), None);
 
-        // Test setting and overwriting fields
-        msg.set_field(1000, "value1".to_string());
-        assert_eq!(msg.get_field(1000), Some(&"value1".to_string()));
+		// Test setting and overwriting fields
+		msg.set_field(1000, "value1".to_string());
+		assert_eq!(msg.get_field(1000), Some(&"value1".to_string()));
 
-        msg.set_field(1000, "value2".to_string());
-        assert_eq!(msg.get_field(1000), Some(&"value2".to_string()));
+		msg.set_field(1000, "value2".to_string());
+		assert_eq!(msg.get_field(1000), Some(&"value2".to_string()));
 
-        // Test with zero tag
-        msg.set_field(0, "zero_tag".to_string());
-        assert_eq!(msg.get_field(0), Some(&"zero_tag".to_string()));
-    }
+		// Test with zero tag
+		msg.set_field(0, "zero_tag".to_string());
+		assert_eq!(msg.get_field(0), Some(&"zero_tag".to_string()));
+	}
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -383,7 +383,11 @@ mod message_parsing_tests {
 
         let result = FixMessage::from_fix_string(fix_string);
 
-        assert!(result.is_ok(), "Failed to parse FIX message: {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "Failed to parse FIX message: {:?}",
+            result.err()
+        );
 
         let message = result.unwrap();
 
@@ -404,7 +408,10 @@ mod message_parsing_tests {
         assert_eq!(message.checksum, "150");
 
         // Verify additional fields are captured
-        assert_eq!(message.get_field(131), Some(&"Q-EURGBP-BUY-3357-636613669639680362".to_string()));
+        assert_eq!(
+            message.get_field(131),
+            Some(&"Q-EURGBP-BUY-3357-636613669639680362".to_string())
+        );
         assert_eq!(message.get_field(146), Some(&"1".to_string()));
         assert_eq!(message.get_field(15), Some(&"EUR".to_string()));
         assert_eq!(message.get_field(64), Some(&"20180508".to_string()));


### PR DESCRIPTION
**Code Formatting and Style:**

* Reformatted code in `src/lib.rs`, `examples/clean_api_demo.rs`, `examples/user_message_builder.rs`, and test files to use hard tabs, reduce line length, and apply more compact formatting for readability and consistency. 

**Toolchain and Formatting Configuration:**

* Added a `rust-toolchain.toml` file to specify the Rust toolchain version (`1.89.0`) and required components (`rustfmt`, `clippy`, `rust-analyzer`).
* Added a `rustfmt.toml` file to enforce consistent formatting rules (e.g., hard tabs, max line width, import ordering, and edition).