### PR TITLE
feat: add time crate 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,121 @@
 version = 4
 
 [[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "fix-learning"
 version = "0.1.0"
+dependencies = [
+ "time",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+time = { version = "0.3", features = ["macros", "formatting", "parsing"] }

--- a/examples/clean_api_demo.rs
+++ b/examples/clean_api_demo.rs
@@ -4,6 +4,7 @@
 //! makes the API more idiomatic and cleaner to use.
 
 use fix_learning::{FixMessage, MsgType, OrdStatus, Side};
+use time::OffsetDateTime;
 
 fn main() {
 	println!("=== Clean API Demo: No More .to_string() Methods! ===\n");
@@ -40,8 +41,8 @@ fn main() {
 		"TRADER",
 		"EXCHANGE",
 		1,
-		"20241201-09:30:00.000",
 	)
+	.sending_time(OffsetDateTime::now_utc())
 	.cl_ord_id("ORDER123")
 	.symbol("AAPL")
 	.side("1".parse().unwrap()) // Clean parsing

--- a/examples/user_message_builder.rs
+++ b/examples/user_message_builder.rs
@@ -4,6 +4,7 @@
 //! 8=FIX.4.2|9=163|35=D|34=972|49=TESTBUY3|52=20190206-16:25:10.403|56=TESTSELL3|11=14163685067084226997921|21=2|38=100|40=1|54=1|55=AAPL|60=20190206-16:25:08.968|207=TO|6000=TEST1234|10=106
 
 use fix_learning::FixMessage;
+use time::macros::datetime;
 
 fn main() {
 	println!("=== Building User's Exact FIX Message ===\n");
@@ -16,12 +17,12 @@ fn main() {
 
 	// Build the exact same message using the builder pattern with FromStr
 	let user_message = FixMessage::builder(
-		"D".parse().unwrap(),    // 35=D (NewOrderSingle) - using FromStr
-		"TESTBUY3",              // 49=TESTBUY3 (SenderCompID)
-		"TESTSELL3",             // 56=TESTSELL3 (TargetCompID)
-		972,                     // 34=972 (MsgSeqNum)
-		"20190206-16:25:10.403", // 52=20190206-16:25:10.403 (SendingTime)
+		"D".parse().unwrap(), // 35=D (NewOrderSingle) - using FromStr
+		"TESTBUY3",           // 49=TESTBUY3 (SenderCompID)
+		"TESTSELL3",          // 56=TESTSELL3 (TargetCompID)
+		972,                  // 34=972 (MsgSeqNum)
 	)
+	.sending_time(datetime!(2019-02-06 16:25:10.403 UTC)) // 52=20190206-16:25:10.403 (SendingTime)
 	// Standard FIX fields
 	.cl_ord_id("14163685067084226997921") // 11=14163685067084226997921 (ClOrdID)
 	.order_qty(100.0) // 38=100 (OrderQty)

--- a/tests/fix_protocol_validation_tests.rs
+++ b/tests/fix_protocol_validation_tests.rs
@@ -1,0 +1,449 @@
+//! Comprehensive tests for FIX protocol validation components
+//!
+//! This test suite validates critical FIX protocol components including:
+//! - Checksum calculation (Tag 10)
+//! - Body length calculation (Tag 9)
+//! - Message integrity validation
+//! - Edge cases and error conditions
+
+use fix_learning::{FixMessage, MsgType, OrdStatus, Side};
+use time::macros::datetime;
+
+#[cfg(test)]
+mod checksum_tests {
+	use super::*;
+
+	#[test]
+	fn test_basic_checksum_calculation() {
+		// Create a simple heartbeat message
+		let message = FixMessage::builder(MsgType::Heartbeat, "CLIENT", "SERVER", 1)
+			.sending_time(datetime!(2024-12-01 12:00:00.000 UTC))
+			.build();
+
+		let fix_string = message.to_fix_string();
+
+		// Extract the checksum from the serialized message
+		let checksum_part = fix_string.split("10=").nth(1).unwrap_or("");
+		let checksum_str = checksum_part.trim_end_matches('\x01');
+
+		// Checksum should be exactly 3 digits
+		assert_eq!(checksum_str.len(), 3);
+		assert!(checksum_str.parse::<u32>().is_ok());
+
+		// Verify checksum is within valid range (000-255)
+		let checksum_value = checksum_str.parse::<u32>().unwrap();
+		assert!(checksum_value <= 255);
+	}
+
+	#[test]
+	fn test_checksum_calculation_algorithm() {
+		// Test the checksum calculation algorithm manually
+		// FIX checksum is sum of all bytes modulo 256, formatted as 3-digit string
+
+		let message = FixMessage::builder(MsgType::NewOrderSingle, "TRADER", "EXCHANGE", 100)
+			.sending_time(datetime!(2024-12-01 09:30:00.000 UTC))
+			.cl_ord_id("ORDER123")
+			.symbol("AAPL")
+			.side(Side::Buy)
+			.order_qty(100.0)
+			.price(150.25)
+			.build();
+
+		let fix_string = message.to_fix_string();
+
+		// Split message to get everything before checksum
+		let parts: Vec<&str> = fix_string.split("10=").collect();
+		assert_eq!(parts.len(), 2, "Message should have exactly one checksum field");
+
+		let message_without_checksum = parts[0];
+
+		// Calculate checksum manually (without adding extra SOH)
+		let calculated_checksum: u32 = message_without_checksum.bytes().map(|b| b as u32).sum::<u32>() % 256;
+
+		// Extract actual checksum from message
+		let actual_checksum_str = parts[1].trim_end_matches('\x01');
+		let actual_checksum = actual_checksum_str.parse::<u32>().unwrap();
+
+		assert_eq!(calculated_checksum, actual_checksum);
+	}
+
+	#[test]
+	fn test_checksum_with_different_message_types() {
+		let test_cases = vec![
+			(MsgType::Heartbeat, "SIMPLE", "TARGET"),
+			(MsgType::NewOrderSingle, "COMPLEX_SENDER_123", "COMPLEX_TARGET_456"),
+			(MsgType::ExecutionReport, "A", "B"),
+			(MsgType::TestRequest, "VERY_LONG_SENDER_COMPANY_ID", "VERY_LONG_TARGET_COMPANY_ID"),
+		];
+
+		for (msg_type, sender, target) in test_cases {
+			let message = FixMessage::builder(msg_type.clone(), sender, target, 1)
+				.sending_time(datetime!(2024-12-01 12:00:00.000 UTC))
+				.build();
+
+			let fix_string = message.to_fix_string();
+
+			// Verify checksum format
+			let checksum_field = fix_string.split("10=").nth(1).unwrap();
+			let checksum_str = checksum_field.trim_end_matches('\x01');
+
+			assert_eq!(checksum_str.len(), 3, "Checksum must be 3 digits for message type {:?}", msg_type);
+			assert!(
+				checksum_str.chars().all(|c| c.is_ascii_digit()),
+				"Checksum must be numeric for message type {:?}",
+				msg_type
+			);
+		}
+	}
+
+	#[test]
+	fn test_checksum_with_special_characters() {
+		// Test checksum calculation with messages containing special characters
+		let message = FixMessage::builder(MsgType::NewOrderSingle, "SENDER", "TARGET", 1)
+			.sending_time(datetime!(2024-12-01 12:00:00.000 UTC))
+			.cl_ord_id("ORDER@123!#$")
+			.symbol("AAPL.USD")
+			.text("Test message with spaces & symbols")
+			.field(5000, "Custom=Value|With|Pipes")
+			.build();
+
+		let fix_string = message.to_fix_string();
+
+		// Verify the message can be parsed back (checksum validation)
+		let parsed = FixMessage::from_fix_string(&fix_string);
+		assert!(parsed.is_ok(), "Message with special characters should parse correctly");
+
+		let parsed_message = parsed.unwrap();
+		assert_eq!(parsed_message.cl_ord_id, Some("ORDER@123!#$".to_string()));
+		assert_eq!(parsed_message.text, Some("Test message with spaces & symbols".to_string()));
+	}
+
+	#[test]
+	fn test_checksum_edge_cases() {
+		// Test edge cases for checksum calculation
+
+		// Empty optional fields
+		let minimal_message = FixMessage::new(MsgType::Heartbeat, "", "", 0);
+		let fix_string = minimal_message.to_fix_string();
+		let checksum_part = fix_string.split("10=").nth(1).unwrap().trim_end_matches('\x01');
+		assert_eq!(checksum_part.len(), 3);
+
+		// Maximum sequence number
+		let max_seq_message = FixMessage::new(MsgType::Heartbeat, "SENDER", "TARGET", u32::MAX);
+		let fix_string = max_seq_message.to_fix_string();
+		let checksum_part = fix_string.split("10=").nth(1).unwrap().trim_end_matches('\x01');
+		assert_eq!(checksum_part.len(), 3);
+
+		// Very long field values
+		let long_text = "A".repeat(1000);
+		let long_message = FixMessage::builder(MsgType::TestRequest, "SENDER", "TARGET", 1)
+			.sending_time(datetime!(2024-12-01 12:00:00.000 UTC))
+			.text(&long_text)
+			.build();
+		let fix_string = long_message.to_fix_string();
+		let checksum_part = fix_string.split("10=").nth(1).unwrap().trim_end_matches('\x01');
+		assert_eq!(checksum_part.len(), 3);
+	}
+}
+
+#[cfg(test)]
+mod body_length_tests {
+	use super::*;
+
+	#[test]
+	fn test_basic_body_length_calculation() {
+		let message = FixMessage::builder(MsgType::Heartbeat, "CLIENT", "SERVER", 1)
+			.sending_time(datetime!(2024-12-01 12:00:00.000 UTC))
+			.build();
+
+		let fix_string = message.to_fix_string();
+
+		// Extract body length from the message
+		let body_length_part = fix_string.split("9=").nth(1).unwrap();
+		let body_length_str = body_length_part.split('\x01').next().unwrap();
+		let body_length = body_length_str.parse::<u32>().unwrap();
+
+		// Calculate expected body length manually
+		// Body starts after "9=XXX\x01" and ends before "10=XXX"
+		let start_marker = format!("9={}\x01", body_length_str);
+		let body_start = fix_string.find(&start_marker).unwrap() + start_marker.len();
+		let body_end = fix_string.rfind("10=").unwrap();
+		let actual_body = &fix_string[body_start..body_end];
+
+		assert_eq!(body_length as usize, actual_body.len());
+	}
+
+	#[test]
+	fn test_body_length_with_various_field_counts() {
+		// Test body length calculation with different numbers of fields
+
+		// Minimal message (only required fields)
+		let minimal = FixMessage::builder(MsgType::Heartbeat, "A", "B", 1)
+			.sending_time(datetime!(2024-12-01 12:00:00.000 UTC))
+			.build();
+		validate_body_length(&minimal);
+
+		// Message with several optional fields
+		let medium = FixMessage::builder(MsgType::NewOrderSingle, "SENDER", "TARGET", 100)
+			.sending_time(datetime!(2024-12-01 12:00:00.000 UTC))
+			.cl_ord_id("ORDER123")
+			.symbol("AAPL")
+			.side(Side::Buy)
+			.build();
+		validate_body_length(&medium);
+
+		// Message with many fields
+		let complex = FixMessage::builder(MsgType::ExecutionReport, "BROKER", "CLIENT", 500)
+			.sending_time(datetime!(2024-12-01 12:00:00.000 UTC))
+			.cl_ord_id("CLIENT_ORDER_789")
+			.order_id("BROKER_ORDER_456")
+			.exec_id("EXEC_001")
+			.exec_type("F")
+			.ord_status(OrdStatus::Filled)
+			.symbol("NVDA")
+			.side(Side::Sell)
+			.order_qty(150.0)
+			.price(500.75)
+			.last_qty(150.0)
+			.last_px(500.80)
+			.leaves_qty(0.0)
+			.cum_qty(150.0)
+			.avg_px(500.80)
+			.text("EXECUTION COMPLETE")
+			.field(207, "NASDAQ")
+			.field(6000, "CUSTOM_DATA")
+			.field(9999, "ANOTHER_CUSTOM_FIELD")
+			.build();
+		validate_body_length(&complex);
+	}
+
+	#[test]
+	fn test_body_length_with_custom_fields() {
+		let message = FixMessage::builder(MsgType::NewOrderSingle, "SENDER", "TARGET", 1)
+			.sending_time(datetime!(2024-12-01 12:00:00.000 UTC))
+			.field(5000, "CustomValue1")
+			.field(5001, "CustomValue2")
+			.field(9999, "VeryLongCustomFieldValueThatShouldBeIncludedInBodyLength")
+			.build();
+
+		validate_body_length(&message);
+
+		// Verify custom fields are included in the body
+		let fix_string = message.to_fix_string();
+		assert!(fix_string.contains("5000=CustomValue1"));
+		assert!(fix_string.contains("5001=CustomValue2"));
+		assert!(fix_string.contains("9999=VeryLongCustomFieldValueThatShouldBeIncludedInBodyLength"));
+	}
+
+	#[test]
+	fn test_body_length_accuracy() {
+		// Test that body length is exactly accurate
+		let message = FixMessage::builder(MsgType::NewOrderSingle, "TRADER", "EXCHANGE", 123)
+			.sending_time(datetime!(2024-12-01 09:30:00.000 UTC))
+			.cl_ord_id("ORDER_456")
+			.symbol("MSFT")
+			.side(Side::Buy)
+			.order_qty(200.0)
+			.price(300.50)
+			.field(60, "20241201-09:30:00.000")
+			.build();
+
+		let fix_string = message.to_fix_string();
+
+		// Parse the message and verify the body length is correct
+		let parsed = FixMessage::from_fix_string(&fix_string).unwrap();
+
+		// Re-serialize and verify body length remains consistent
+		let re_serialized = parsed.to_fix_string();
+		let original_body_length = extract_body_length(&fix_string);
+		let re_serialized_body_length = extract_body_length(&re_serialized);
+
+		assert_eq!(original_body_length, re_serialized_body_length);
+	}
+
+	#[test]
+	fn test_body_length_with_unicode_characters() {
+		// Test body length calculation with Unicode characters
+		let message = FixMessage::builder(MsgType::NewOrderSingle, "SENDER", "TARGET", 1)
+			.sending_time(datetime!(2024-12-01 12:00:00.000 UTC))
+			.text("Test with émojis 🚀 and ñoñó")
+			.field(6000, "价格信息") // Chinese characters
+			.build();
+
+		validate_body_length(&message);
+
+		// Verify the message can be parsed back correctly
+		let fix_string = message.to_fix_string();
+		let parsed = FixMessage::from_fix_string(&fix_string);
+		assert!(parsed.is_ok());
+	}
+
+	#[test]
+	fn test_body_length_edge_cases() {
+		// Test edge cases for body length calculation
+
+		// Message with zero-length optional fields
+		let message_with_empty_fields = FixMessage::builder(MsgType::TestRequest, "SENDER", "TARGET", 1)
+			.sending_time(datetime!(2024-12-01 12:00:00.000 UTC))
+			.cl_ord_id("")
+			.text("")
+			.field(6000, "")
+			.build();
+		validate_body_length(&message_with_empty_fields);
+
+		// Message with very large field values
+		let large_value = "X".repeat(5000);
+		let large_message = FixMessage::builder(MsgType::NewOrderSingle, "SENDER", "TARGET", 1)
+			.sending_time(datetime!(2024-12-01 12:00:00.000 UTC))
+			.text(&large_value)
+			.build();
+		validate_body_length(&large_message);
+	}
+
+	// Helper function to validate body length calculation
+	fn validate_body_length(message: &FixMessage) {
+		let fix_string = message.to_fix_string();
+		let calculated_body_length = extract_body_length(&fix_string);
+		let actual_body_length = calculate_actual_body_length(&fix_string);
+
+		assert_eq!(
+			calculated_body_length,
+			actual_body_length,
+			"Body length mismatch in message: {}",
+			fix_string.replace('\x01', " | ")
+		);
+	}
+
+	// Helper function to extract body length from FIX string
+	fn extract_body_length(fix_string: &str) -> u32 {
+		let body_length_part = fix_string.split("9=").nth(1).unwrap();
+		let body_length_str = body_length_part.split('\x01').next().unwrap();
+		body_length_str.parse::<u32>().unwrap()
+	}
+
+	// Helper function to calculate actual body length
+	fn calculate_actual_body_length(fix_string: &str) -> u32 {
+		// Find the start of the body (after "9=XXX\x01")
+		let body_length_field_end = fix_string.find("9=").unwrap();
+		let body_start = fix_string[body_length_field_end..].find('\x01').unwrap() + body_length_field_end + 1;
+
+		// Find the end of the body (before "10=XXX")
+		let body_end = fix_string.rfind("10=").unwrap();
+
+		// Calculate the actual body length
+		(body_end - body_start) as u32
+	}
+}
+
+#[cfg(test)]
+mod message_integrity_tests {
+	use super::*;
+
+	#[test]
+	fn test_complete_message_validation() {
+		// Test that messages with correct checksum and body length parse successfully
+		let message = FixMessage::builder(MsgType::ExecutionReport, "BROKER", "CLIENT", 100)
+			.sending_time(datetime!(2024-12-01 10:30:00.500 UTC))
+			.cl_ord_id("ORDER_123")
+			.order_id("BROKER_456")
+			.exec_id("EXEC_789")
+			.ord_status(OrdStatus::Filled)
+			.symbol("AAPL")
+			.side(Side::Buy)
+			.order_qty(100.0)
+			.last_qty(100.0)
+			.last_px(150.25)
+			.leaves_qty(0.0)
+			.cum_qty(100.0)
+			.avg_px(150.25)
+			.build();
+
+		let fix_string = message.to_fix_string();
+
+		// Verify the message can be parsed back
+		let parsed = FixMessage::from_fix_string(&fix_string);
+		assert!(parsed.is_ok());
+
+		let parsed_message = parsed.unwrap();
+
+		// Verify all fields are preserved
+		assert_eq!(parsed_message.msg_type, MsgType::ExecutionReport);
+		assert_eq!(parsed_message.sender_comp_id, "BROKER");
+		assert_eq!(parsed_message.target_comp_id, "CLIENT");
+		assert_eq!(parsed_message.msg_seq_num, 100);
+		assert_eq!(parsed_message.cl_ord_id, Some("ORDER_123".to_string()));
+		assert_eq!(parsed_message.order_id, Some("BROKER_456".to_string()));
+		assert_eq!(parsed_message.exec_id, Some("EXEC_789".to_string()));
+		assert_eq!(parsed_message.ord_status, Some(OrdStatus::Filled));
+		assert_eq!(parsed_message.symbol, Some("AAPL".to_string()));
+		assert_eq!(parsed_message.side, Some(Side::Buy));
+		assert_eq!(parsed_message.order_qty, Some(100.0));
+		assert_eq!(parsed_message.last_qty, Some(100.0));
+		assert_eq!(parsed_message.last_px, Some(150.25));
+		assert_eq!(parsed_message.leaves_qty, Some(0.0));
+		assert_eq!(parsed_message.cum_qty, Some(100.0));
+		assert_eq!(parsed_message.avg_px, Some(150.25));
+	}
+
+	#[test]
+	fn test_round_trip_consistency() {
+		// Test that serialization -> parsing -> serialization produces identical results
+		let original = FixMessage::builder(MsgType::NewOrderSingle, "TRADER", "EXCHANGE", 50)
+			.sending_time(datetime!(2024-12-01 15:45:30.123 UTC))
+			.cl_ord_id("ROUND_TRIP_TEST")
+			.symbol("GOOGL")
+			.side(Side::Sell)
+			.order_qty(75.0)
+			.price(2800.50)
+			.field(207, "NASDAQ")
+			.field(6000, "ROUND_TRIP_DATA")
+			.build();
+
+		let first_serialization = original.to_fix_string();
+		let parsed = FixMessage::from_fix_string(&first_serialization).unwrap();
+		let second_serialization = parsed.to_fix_string();
+
+		// The two serializations should be identical
+		assert_eq!(first_serialization, second_serialization);
+
+		// Extract and verify checksums are identical
+		let first_checksum = first_serialization.split("10=").nth(1).unwrap().trim_end_matches('\x01');
+		let second_checksum = second_serialization.split("10=").nth(1).unwrap().trim_end_matches('\x01');
+		assert_eq!(first_checksum, second_checksum);
+
+		// Extract and verify body lengths are identical
+		let first_body_length = first_serialization.split("9=").nth(1).unwrap().split('\x01').next().unwrap();
+		let second_body_length = second_serialization.split("9=").nth(1).unwrap().split('\x01').next().unwrap();
+		assert_eq!(first_body_length, second_body_length);
+	}
+
+	#[test]
+	fn test_field_ordering_consistency() {
+		// Test that field ordering is consistent and doesn't affect checksum/body length
+		let message = FixMessage::builder(MsgType::NewOrderSingle, "SENDER", "TARGET", 1)
+			.sending_time(datetime!(2024-12-01 12:00:00.000 UTC))
+			.field(6000, "CUSTOM1") // Add custom fields in different orders
+			.cl_ord_id("ORDER123")
+			.field(207, "EXCHANGE")
+			.symbol("AAPL")
+			.field(9999, "CUSTOM2")
+			.side(Side::Buy)
+			.order_qty(100.0)
+			.build();
+
+		let fix_string = message.to_fix_string();
+
+		// Verify the message parses correctly
+		let parsed = FixMessage::from_fix_string(&fix_string);
+		assert!(parsed.is_ok());
+
+		// Verify custom fields are in the correct order in the serialized message
+		let custom_field_6000_pos = fix_string.find("6000=CUSTOM1").unwrap();
+		let custom_field_207_pos = fix_string.find("207=EXCHANGE").unwrap();
+		let custom_field_9999_pos = fix_string.find("9999=CUSTOM2").unwrap();
+
+		// Custom fields should appear in ascending tag order
+		assert!(custom_field_207_pos < custom_field_6000_pos);
+		assert!(custom_field_6000_pos < custom_field_9999_pos);
+	}
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -13,13 +13,7 @@ mod trading_workflow_tests {
 	#[test]
 	fn complete_order_lifecycle() {
 		// 1. Client sends New Order Single
-		let mut new_order = FixMessage::new(
-			MsgType::NewOrderSingle,
-			"CLIENT_TRADER".to_string(),
-			"PRIME_BROKER".to_string(),
-			1,
-			"20241201-09:30:00.000".to_string(),
-		);
+		let mut new_order = FixMessage::new(MsgType::NewOrderSingle, "CLIENT_TRADER", "PRIME_BROKER", 1);
 
 		new_order.cl_ord_id = Some("CLIENT_ORD_001".to_string());
 		new_order.symbol = Some("AAPL".to_string());
@@ -33,13 +27,7 @@ mod trading_workflow_tests {
 		assert_eq!(new_order.msg_type, MsgType::NewOrderSingle);
 
 		// 2. Broker responds with Execution Report (New)
-		let mut exec_new = FixMessage::new(
-			MsgType::ExecutionReport,
-			"PRIME_BROKER".to_string(),
-			"CLIENT_TRADER".to_string(),
-			1,
-			"20241201-09:30:00.100".to_string(),
-		);
+		let mut exec_new = FixMessage::new(MsgType::ExecutionReport, "PRIME_BROKER", "CLIENT_TRADER", 1);
 
 		exec_new.cl_ord_id = Some("CLIENT_ORD_001".to_string());
 		exec_new.order_id = Some("BROKER_ORD_12345".to_string());
@@ -57,13 +45,7 @@ mod trading_workflow_tests {
 		assert_eq!(exec_new.leaves_qty, Some(1000.0));
 
 		// 3. Partial fill occurs
-		let mut exec_partial = FixMessage::new(
-			MsgType::ExecutionReport,
-			"PRIME_BROKER".to_string(),
-			"CLIENT_TRADER".to_string(),
-			2,
-			"20241201-09:30:15.250".to_string(),
-		);
+		let mut exec_partial = FixMessage::new(MsgType::ExecutionReport, "PRIME_BROKER", "CLIENT_TRADER", 2);
 
 		exec_partial.cl_ord_id = Some("CLIENT_ORD_001".to_string());
 		exec_partial.order_id = Some("BROKER_ORD_12345".to_string());
@@ -84,13 +66,7 @@ mod trading_workflow_tests {
 		assert_eq!(exec_partial.leaves_qty, Some(600.0));
 
 		// 4. Final fill completes the order
-		let mut exec_filled = FixMessage::new(
-			MsgType::ExecutionReport,
-			"PRIME_BROKER".to_string(),
-			"CLIENT_TRADER".to_string(),
-			3,
-			"20241201-09:30:45.500".to_string(),
-		);
+		let mut exec_filled = FixMessage::new(MsgType::ExecutionReport, "PRIME_BROKER", "CLIENT_TRADER", 3);
 
 		exec_filled.cl_ord_id = Some("CLIENT_ORD_001".to_string());
 		exec_filled.order_id = Some("BROKER_ORD_12345".to_string());
@@ -114,13 +90,7 @@ mod trading_workflow_tests {
 	#[test]
 	fn order_cancel_workflow() {
 		// 1. Original order
-		let mut original_order = FixMessage::new(
-			MsgType::NewOrderSingle,
-			"HEDGE_FUND".to_string(),
-			"ECN_BROKER".to_string(),
-			10,
-			"20241201-10:15:00.000".to_string(),
-		);
+		let mut original_order = FixMessage::new(MsgType::NewOrderSingle, "HEDGE_FUND", "ECN_BROKER", 10);
 
 		original_order.cl_ord_id = Some("HF_ORDER_500".to_string());
 		original_order.symbol = Some("TSLA".to_string());
@@ -130,13 +100,7 @@ mod trading_workflow_tests {
 		original_order.price = Some(245.75);
 
 		// 2. Order acknowledged
-		let mut ack_report = FixMessage::new(
-			MsgType::ExecutionReport,
-			"ECN_BROKER".to_string(),
-			"HEDGE_FUND".to_string(),
-			10,
-			"20241201-10:15:00.050".to_string(),
-		);
+		let mut ack_report = FixMessage::new(MsgType::ExecutionReport, "ECN_BROKER", "HEDGE_FUND", 10);
 
 		ack_report.cl_ord_id = Some("HF_ORDER_500".to_string());
 		ack_report.order_id = Some("ECN_12345".to_string());
@@ -147,13 +111,7 @@ mod trading_workflow_tests {
 		ack_report.cum_qty = Some(0.0);
 
 		// 3. Client decides to cancel
-		let mut cancel_request = FixMessage::new(
-			MsgType::OrderCancelRequest,
-			"HEDGE_FUND".to_string(),
-			"ECN_BROKER".to_string(),
-			11,
-			"20241201-10:16:30.000".to_string(),
-		);
+		let mut cancel_request = FixMessage::new(MsgType::OrderCancelRequest, "HEDGE_FUND", "ECN_BROKER", 11);
 
 		cancel_request.cl_ord_id = Some("HF_ORDER_500".to_string());
 		cancel_request.order_id = Some("ECN_12345".to_string());
@@ -162,13 +120,7 @@ mod trading_workflow_tests {
 		cancel_request.order_qty = Some(2000.0);
 
 		// 4. Broker confirms cancellation
-		let mut cancel_report = FixMessage::new(
-			MsgType::ExecutionReport,
-			"ECN_BROKER".to_string(),
-			"HEDGE_FUND".to_string(),
-			11,
-			"20241201-10:16:30.100".to_string(),
-		);
+		let mut cancel_report = FixMessage::new(MsgType::ExecutionReport, "ECN_BROKER", "HEDGE_FUND", 11);
 
 		cancel_report.cl_ord_id = Some("HF_ORDER_500".to_string());
 		cancel_report.order_id = Some("ECN_12345".to_string());
@@ -192,13 +144,7 @@ mod trading_workflow_tests {
 		let new_cl_ord_id = "PROP_TRADE_100_R1";
 
 		// 2. Order replace request
-		let mut replace_request = FixMessage::new(
-			MsgType::OrderCancelReplaceRequest,
-			"PROP_DESK".to_string(),
-			"DARK_POOL".to_string(),
-			25,
-			"20241201-11:30:00.000".to_string(),
-		);
+		let mut replace_request = FixMessage::new(MsgType::OrderCancelReplaceRequest, "PROP_DESK", "DARK_POOL", 25);
 
 		replace_request.cl_ord_id = Some(new_cl_ord_id.to_string());
 		replace_request.order_id = Some("DARK_567890".to_string());
@@ -211,13 +157,7 @@ mod trading_workflow_tests {
 		replace_request.set_field(41, original_cl_ord_id.to_string()); // OrigClOrdID
 
 		// 3. Replace confirmation
-		let mut replace_report = FixMessage::new(
-			MsgType::ExecutionReport,
-			"DARK_POOL".to_string(),
-			"PROP_DESK".to_string(),
-			25,
-			"20241201-11:30:00.150".to_string(),
-		);
+		let mut replace_report = FixMessage::new(MsgType::ExecutionReport, "DARK_POOL", "PROP_DESK", 25);
 
 		replace_report.cl_ord_id = Some(new_cl_ord_id.to_string());
 		replace_report.order_id = Some("DARK_567890".to_string());
@@ -247,7 +187,6 @@ mod trading_workflow_tests {
 			"CLIENT_SYSTEM".to_string(),
 			"MARKET_DATA_PROVIDER".to_string(),
 			sequence_num,
-			"20241201-12:00:00.000".to_string(),
 		);
 
 		sequence_num += 1;
@@ -258,7 +197,6 @@ mod trading_workflow_tests {
 			"MARKET_DATA_PROVIDER".to_string(),
 			"CLIENT_SYSTEM".to_string(),
 			sequence_num,
-			"20241201-12:00:00.100".to_string(),
 		);
 
 		assert_eq!(client_heartbeat.msg_type, MsgType::Heartbeat);
@@ -275,7 +213,6 @@ mod trading_workflow_tests {
 			"TRADING_ENGINE".to_string(),
 			"MARKET_DATA_SERVICE".to_string(),
 			50,
-			"20241201-13:15:00.000".to_string(),
 		);
 
 		md_request.symbol = Some("SPY".to_string());
@@ -284,13 +221,7 @@ mod trading_workflow_tests {
 		md_request.set_field(264, "1".to_string()); // MarketDepth (Top of book)
 
 		// Market data snapshot response
-		let mut md_snapshot = FixMessage::new(
-			MsgType::MarketDataSnapshot,
-			"MARKET_DATA_SERVICE".to_string(),
-			"TRADING_ENGINE".to_string(),
-			50,
-			"20241201-13:15:00.050".to_string(),
-		);
+		let mut md_snapshot = FixMessage::new(MsgType::MarketDataSnapshot, "MARKET_DATA_SERVICE", "TRADING_ENGINE", 50);
 
 		md_snapshot.symbol = Some("SPY".to_string());
 		md_snapshot.set_field(262, "SPY_L1_FEED".to_string()); // MDReqID
@@ -308,13 +239,7 @@ mod trading_workflow_tests {
 	#[test]
 	fn reject_message() {
 		// Invalid order that gets rejected
-		let mut reject_msg = FixMessage::new(
-			MsgType::Reject,
-			"EXCHANGE".to_string(),
-			"BAD_CLIENT".to_string(),
-			999,
-			"20241201-14:00:00.000".to_string(),
-		);
+		let mut reject_msg = FixMessage::new(MsgType::Reject, "EXCHANGE", "BAD_CLIENT", 999);
 
 		reject_msg.text = Some("Invalid symbol: INVALID_SYM".to_string());
 		reject_msg.set_field(45, "1000".to_string()); // RefSeqNum - sequence number being rejected
@@ -330,26 +255,15 @@ mod trading_workflow_tests {
 	#[test]
 	fn security_definition_workflow() {
 		// Security definition request
-		let mut sec_def_request = FixMessage::new(
-			MsgType::SecurityDefinitionRequest,
-			"RISK_SYSTEM".to_string(),
-			"REFERENCE_DATA".to_string(),
-			200,
-			"20241201-08:00:00.000".to_string(),
-		);
+		let mut sec_def_request =
+			FixMessage::new(MsgType::SecurityDefinitionRequest, "RISK_SYSTEM", "REFERENCE_DATA", 200);
 
 		sec_def_request.symbol = Some("MSFT".to_string());
 		sec_def_request.set_field(320, "SEC_DEF_REQ_001".to_string()); // SecurityReqID
 		sec_def_request.set_field(321, "1".to_string()); // SecurityRequestType
 
 		// Security definition response
-		let mut sec_def_response = FixMessage::new(
-			MsgType::SecurityDefinition,
-			"REFERENCE_DATA".to_string(),
-			"RISK_SYSTEM".to_string(),
-			200,
-			"20241201-08:00:00.100".to_string(),
-		);
+		let mut sec_def_response = FixMessage::new(MsgType::SecurityDefinition, "REFERENCE_DATA", "RISK_SYSTEM", 200);
 
 		sec_def_response.symbol = Some("MSFT".to_string());
 		sec_def_response.security_type = Some("CS".to_string()); // Common Stock
@@ -365,6 +279,8 @@ mod trading_workflow_tests {
 
 #[cfg(test)]
 mod message_parsing_tests {
+	use time::macros::datetime;
+
 	use super::*;
 
 	#[test]
@@ -385,7 +301,7 @@ mod message_parsing_tests {
 		assert_eq!(message.msg_type, MsgType::Other("R".to_string())); // Quote Request
 		assert_eq!(message.msg_seq_num, 3257);
 		assert_eq!(message.sender_comp_id, "COMP-PRICES");
-		assert_eq!(message.sending_time, "20180508-09:02:43.968");
+		assert_eq!(message.sending_time, datetime!(2018-05-08 09:02:43.968 UTC));
 		assert_eq!(message.target_comp_id, "BANK-PRICES");
 
 		// Verify message-specific fields
@@ -423,7 +339,7 @@ mod message_parsing_tests {
 		assert_eq!(message.msg_type, MsgType::NewOrderSingle);
 		assert_eq!(message.msg_seq_num, 972);
 		assert_eq!(message.sender_comp_id, "TESTBUY3");
-		assert_eq!(message.sending_time, "20190206-16:25:10.403");
+		assert_eq!(message.sending_time, datetime!(2019-02-06 16:25:10.403 UTC));
 		assert_eq!(message.target_comp_id, "TESTSELL3");
 
 		// Verify order-specific fields
@@ -477,7 +393,7 @@ mod message_parsing_tests {
 		assert_eq!(message.msg_type, MsgType::ExecutionReport);
 		assert_eq!(message.msg_seq_num, 974);
 		assert_eq!(message.sender_comp_id, "TESTSELL3");
-		assert_eq!(message.sending_time, "20190206-16:26:09.059");
+		assert_eq!(message.sending_time, datetime!(2019-02-06 16:26:09.059 UTC));
 		assert_eq!(message.target_comp_id, "TESTBUY3");
 
 		// Verify execution-specific fields
@@ -541,7 +457,7 @@ mod message_parsing_tests {
 		assert_eq!(message.msg_type, MsgType::Other("A".to_string())); // Logon
 		assert_eq!(message.msg_seq_num, 978);
 		assert_eq!(message.sender_comp_id, "TESTSELL3");
-		assert_eq!(message.sending_time, "20190206-16:29:19.208");
+		assert_eq!(message.sending_time, datetime!(2019-02-06 16:29:19.208 UTC));
 		assert_eq!(message.target_comp_id, "TESTBUY3");
 
 		// Verify logon-specific fields (as additional fields since they're not standard body fields)
@@ -584,7 +500,7 @@ mod message_parsing_tests {
 		assert_eq!(message.msg_type, MsgType::Logout);
 		assert_eq!(message.msg_seq_num, 977);
 		assert_eq!(message.sender_comp_id, "TESTSELL3");
-		assert_eq!(message.sending_time, "20190206-16:28:51.518");
+		assert_eq!(message.sending_time, datetime!(2019-02-06 16:28:51.518 UTC));
 		assert_eq!(message.target_comp_id, "TESTBUY3");
 
 		// Verify checksum
@@ -621,15 +537,6 @@ mod error_handling_tests {
 		invalid_msg.sender_comp_id = "VALID_SENDER".to_string();
 		invalid_msg.target_comp_id = "".to_string();
 		assert!(!invalid_msg.is_valid());
-
-		// Fix target, but empty sending time
-		invalid_msg.target_comp_id = "VALID_TARGET".to_string();
-		invalid_msg.sending_time = "".to_string();
-		assert!(!invalid_msg.is_valid());
-
-		// Fix sending time - should now be valid
-		invalid_msg.sending_time = "20241201-12:00:00.000".to_string();
-		assert!(invalid_msg.is_valid());
 	}
 
 	#[test]


### PR DESCRIPTION
**Core API and Timestamp Handling Improvements:**

- Replaced all string-based timestamp fields (e.g., `sending_time`, `orig_sending_time`) in `FixMessage` and related builder APIs with the strongly-typed `OffsetDateTime` from the `time` crate, improving type safety and eliminating manual formatting/parsing. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L67-R81) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L112-R129) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L190-R197) [[4]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L216-R227)
- Added new methods to the builder for setting `sending_time` and `orig_sending_time` using `OffsetDateTime`, and defaulted `sending_time` to the current UTC time when not provided. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L216-R227) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L112-R129)
- Implemented robust timestamp parsing and formatting according to the FIX specification, including leap second support, using `time` crate formatting macros and a new `parse_fix_timestamp` helper. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L55-R64) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R560-R579)

**Serialization and Parsing Enhancements:**

- Updated `FixMessage::to_fix_string` to serialize timestamps in the correct FIX format with millisecond precision, and to correctly calculate the `BodyLength` and append the SOH character at the end of the message. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L380-R391) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L391-R403) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L470-R483) [[4]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L482-R495)
- Improved `FixMessage::from_fix_string` to parse timestamps into `OffsetDateTime` and to handle optional and leap second fields per the FIX spec. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L498-R526) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R560-R579)

**Documentation, Examples, and Tests:**

- Updated all documentation, examples, and tests to use the new timestamp API, demonstrating both automatic and explicit timestamp handling with `OffsetDateTime` and the `time` crate macros. (README.md: [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R66-R87) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R101-L120) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L133-R135) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L155-R161) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L231-R240); examples: [[6]](diffhunk://#diff-c4610fced4cb5337b26ff3874a876840e55caa9b65bc309c7a2ee808ed8cf731R7) [[7]](diffhunk://#diff-c4610fced4cb5337b26ff3874a876840e55caa9b65bc309c7a2ee808ed8cf731L43-R45) [[8]](diffhunk://#diff-cab43210a0829dfb00b1ab4f0cf9dde13cc29d756f720f5886f975f93d8cd500R7) [[9]](diffhunk://#diff-cab43210a0829dfb00b1ab4f0cf9dde13cc29d756f720f5886f975f93d8cd500L23-R25); tests: [[10]](diffhunk://#diff-995b66646705969fec3a9819a0dd4554864c06a4ab539714b507dc87bce641bdR8-R27) [[11]](diffhunk://#diff-995b66646705969fec3a9819a0dd4554864c06a4ab539714b507dc87bce641bdL45-R46) [[12]](diffhunk://#diff-995b66646705969fec3a9819a0dd4554864c06a4ab539714b507dc87bce641bdL60-R61)
- Added `time` crate as a dependency with relevant features enabled in `Cargo.toml`.

These changes make the FIX message API safer, more idiomatic, and more standards-compliant, especially regarding time handling.