### PR TITLE
feat: add benchmarks! 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,6 @@ name = "fix-learning"
 version = "0.1.0"
 dependencies = [
  "criterion",
- "smallvec",
  "time",
 ]
 
@@ -414,12 +413,6 @@ dependencies = [
  "ryu",
  "serde",
 ]
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,167 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,10 +173,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "fix-learning"
 version = "0.1.0"
 dependencies = [
+ "criterion",
+ "smallvec",
  "time",
+]
+
+[[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -25,10 +213,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "powerfmt"
@@ -55,6 +314,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +402,24 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "serde_json"
+version = "1.0.142"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "syn"
@@ -117,7 +464,177 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ time = { version = "0.3", features = ["macros", "formatting", "parsing"] }
 
 [dev-dependencies]
 criterion = { version = "0.7", features = ["html_reports"] }
-smallvec = "1.11"
 
 [[bench]]
 name = "fix_benchmarks"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,11 @@ edition = "2024"
 
 [dependencies]
 time = { version = "0.3", features = ["macros", "formatting", "parsing"] }
+
+[dev-dependencies]
+criterion = { version = "0.7", features = ["html_reports"] }
+smallvec = "1.11"
+
+[[bench]]
+name = "fix_benchmarks"
+harness = false

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,87 @@
+# FIX Learning Benchmarks
+
+This directory contains comprehensive Criterion.rs benchmarks for the FIX Learning library, designed to measure performance and identify optimization opportunities.
+
+## Quick Start
+
+```bash
+# Run all benchmarks
+./run_benchmarks.sh
+
+# Run specific benchmark suite
+cargo bench --bench fix_benchmarks
+cargo bench --bench optimization_benchmarks
+
+# View HTML reports
+open target/criterion/report/index.html
+```
+
+## Benchmark Suites
+
+### Core FIX Benchmarks (`fix_benchmarks.rs`)
+
+**Message Creation**
+- `heartbeat` - Simple message creation overhead
+- `simple_new_order` - Basic order creation with required fields
+- `complex_new_order` - Order with custom fields and timestamps
+- `execution_report` - Full execution report with all fields
+
+**Serialization Performance**
+- `to_fix_string` - Converting messages to FIX wire format
+- Tests across different message types and complexities
+
+**Parsing Performance**
+- `from_fix_string` - Parsing FIX strings back to message objects
+- Includes validation and field extraction overhead
+
+**Round-trip Performance**
+- `serialize_parse` - Complete serialize → parse cycle
+- Critical for high-frequency trading scenarios
+
+**Enum Operations**
+- `msg_type_parsing` - MsgType enum FromStr performance
+- `side_parsing` - Side enum conversion
+- `ord_status_parsing` - Order status enum handling
+
+**Field Operations**
+- `set_custom_field` - Adding custom fields to messages
+- `get_custom_field` - Retrieving custom field values
+- `validation` - Message validation overhead
+
+**Message Size Impact**
+- Small/Medium/Large message handling
+- Memory usage scaling with message complexity
+
+**Memory Patterns**
+- `batch_message_creation` - Creating many messages in sequence
+- `builder_reuse_pattern` - Builder pattern efficiency
+
+## Key Metrics to Monitor
+
+### Performance Indicators
+- **Throughput**: Messages processed per second
+- **Latency**: Time per message operation
+- **Memory**: Allocation patterns and peak usage
+
+### Critical Benchmarks for Trading Systems
+1. **`simple_new_order`** - Core order creation latency
+2. **`serialization`** - Wire format conversion speed
+3. **`parsing`** - Incoming message processing speed
+4. **`batch_creation`** - High-frequency trading scenarios
+
+### Optimization Opportunities
+1. **Memory allocation** - Compare current vs optimized approaches
+2. **Field storage** - BTreeMap vs SmallVec trade-offs
+3. **String handling** - Stack vs heap allocation patterns
+
+## Understanding Results
+
+### Interpreting Criterion Output
+```
+message_creation/heartbeat  time: [1.2345 µs 1.2567 µs 1.2789 µs]
+                           change: [+2.34% +3.45% +4.56%] (p = 0.00 < 0.05)
+```
+
+- **First line**: [lower_bound mean upper_bound] confidence interval
+- **Second line**: Performance change vs previous run
+- **p-value**: Statistical significance (< 0.05 is significant)

--- a/benches/fix_benchmarks.rs
+++ b/benches/fix_benchmarks.rs
@@ -1,0 +1,399 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use fix_learning::{FixMessage, MsgType, OrdStatus, Side};
+use std::{hint::black_box, str::FromStr};
+use time::macros::datetime;
+
+// Sample FIX message data for benchmarks
+const SAMPLE_FIX_STRINGS: &[&str] = &[
+	// Simple Heartbeat
+	"8=FIX.4.2\x019=40\x0135=0\x0149=SENDER\x0156=TARGET\x0134=1\x0152=20241201-12:00:00.000\x0110=123\x01",
+	// New Order Single
+	"8=FIX.4.2\x019=163\x0135=D\x0134=972\x0149=TESTBUY3\x0152=20190206-16:25:10.403\x0156=TESTSELL3\x0111=14163685067084226997921\x0121=2\x0138=100\x0140=1\x0154=1\x0155=AAPL\x0160=20190206-16:25:08.968\x01207=TO\x016000=TEST1234\x0110=106\x01",
+	// Execution Report
+	"8=FIX.4.2\x019=200\x0135=8\x0149=BROKER\x0156=CLIENT\x0134=100\x0152=20241201-12:00:00.000\x0137=ORDER001\x0111=CLIENT001\x0117=EXEC001\x01150=F\x0139=2\x0155=MSFT\x0154=1\x0138=500\x0131=155.75\x0132=500\x0114=500\x01151=0\x016=155.75\x0110=123\x01",
+	// Order Cancel Request
+	"8=FIX.4.2\x019=120\x0135=F\x0149=CLIENT\x0156=BROKER\x0134=50\x0152=20241201-12:00:00.000\x0137=ORDER001\x0111=CANCEL001\x0141=CLIENT001\x0155=GOOGL\x0154=2\x0138=100\x0110=123\x01",
+	// Market Data Request
+	"8=FIX.4.2\x019=150\x0135=V\x0149=CLIENT\x0156=MARKET\x0134=25\x0152=20241201-12:00:00.000\x01262=MDREQ001\x01263=1\x01264=20\x01267=2\x01269=0\x01269=1\x01146=1\x0155=AAPL\x0110=123\x01",
+];
+
+fn create_sample_messages() -> Vec<FixMessage> {
+	vec![
+		// Heartbeat
+		FixMessage::builder(MsgType::Heartbeat, "SENDER", "TARGET", 1).build(),
+		// New Order Single
+		FixMessage::builder(MsgType::NewOrderSingle, "TESTBUY3", "TESTSELL3", 972)
+			.sending_time(datetime!(2019-02-06 16:25:10.403 UTC))
+			.cl_ord_id("14163685067084226997921")
+			.symbol("AAPL")
+			.side(Side::Buy)
+			.order_qty(100.0)
+			.field(207, "TO")
+			.field(6000, "TEST1234")
+			.build(),
+		// Execution Report
+		FixMessage::builder(MsgType::ExecutionReport, "BROKER", "CLIENT", 100)
+			.order_id("ORDER001")
+			.cl_ord_id("CLIENT001")
+			.exec_id("EXEC001")
+			.exec_type("F")
+			.ord_status(OrdStatus::Filled)
+			.symbol("MSFT")
+			.side(Side::Buy)
+			.order_qty(500.0)
+			.last_px(155.75)
+			.last_qty(500.0)
+			.cum_qty(500.0)
+			.leaves_qty(0.0)
+			.avg_px(155.75)
+			.build(),
+		// Order Cancel Request
+		FixMessage::builder(MsgType::OrderCancelRequest, "CLIENT", "BROKER", 50)
+			.order_id("ORDER001")
+			.cl_ord_id("CANCEL001")
+			.symbol("GOOGL")
+			.side(Side::Sell)
+			.order_qty(100.0)
+			.build(),
+		// Market Data Request
+		FixMessage::builder(MsgType::MarketDataRequest, "CLIENT", "MARKET", 25)
+			.field(262, "MDREQ001") // MDReqID
+			.field(263, "1") // SubscriptionRequestType
+			.field(264, "20") // MarketDepth
+			.field(267, "2") // NoMDEntryTypes
+			.field(269, "0") // MDEntryType - Bid
+			.field(269, "1") // MDEntryType - Offer
+			.field(146, "1") // NoRelatedSym
+			.symbol("AAPL")
+			.build(),
+	]
+}
+
+// Benchmark message creation using builder pattern
+fn bench_message_creation(c: &mut Criterion) {
+	let mut group = c.benchmark_group("message_creation");
+
+	group.bench_function("heartbeat", |b| {
+		b.iter(|| {
+			black_box(
+				FixMessage::builder(
+					black_box(MsgType::Heartbeat),
+					black_box("SENDER"),
+					black_box("TARGET"),
+					black_box(1),
+				)
+				.build(),
+			)
+		})
+	});
+
+	group.bench_function("simple_new_order", |b| {
+		b.iter(|| {
+			black_box(
+				FixMessage::builder(
+					black_box(MsgType::NewOrderSingle),
+					black_box("CLIENT"),
+					black_box("BROKER"),
+					black_box(100),
+				)
+				.cl_ord_id(black_box("ORDER123"))
+				.symbol(black_box("AAPL"))
+				.side(black_box(Side::Buy))
+				.order_qty(black_box(100.0))
+				.price(black_box(150.25))
+				.build(),
+			)
+		})
+	});
+
+	group.bench_function("complex_new_order", |b| {
+		b.iter(|| {
+			black_box(
+				FixMessage::builder(
+					black_box(MsgType::NewOrderSingle),
+					black_box("TESTBUY3"),
+					black_box("TESTSELL3"),
+					black_box(972),
+				)
+				.sending_time(black_box(datetime!(2019-02-06 16:25:10.403 UTC)))
+				.cl_ord_id(black_box("14163685067084226997921"))
+				.symbol(black_box("AAPL"))
+				.side(black_box(Side::Buy))
+				.order_qty(black_box(100.0))
+				.field(black_box(207), black_box("TO"))
+				.field(black_box(6000), black_box("TEST1234"))
+				.build(),
+			)
+		})
+	});
+
+	group.bench_function("execution_report", |b| {
+		b.iter(|| {
+			black_box(
+				FixMessage::builder(
+					black_box(MsgType::ExecutionReport),
+					black_box("BROKER"),
+					black_box("CLIENT"),
+					black_box(100),
+				)
+				.order_id(black_box("ORDER001"))
+				.cl_ord_id(black_box("CLIENT001"))
+				.exec_id(black_box("EXEC001"))
+				.exec_type(black_box("F"))
+				.ord_status(black_box(OrdStatus::Filled))
+				.symbol(black_box("MSFT"))
+				.side(black_box(Side::Buy))
+				.order_qty(black_box(500.0))
+				.last_px(black_box(155.75))
+				.last_qty(black_box(500.0))
+				.cum_qty(black_box(500.0))
+				.leaves_qty(black_box(0.0))
+				.avg_px(black_box(155.75))
+				.build(),
+			)
+		})
+	});
+
+	group.finish();
+}
+
+// Benchmark serialization to FIX string
+fn bench_serialization(c: &mut Criterion) {
+	let messages = create_sample_messages();
+	let mut group = c.benchmark_group("serialization");
+
+	for (i, message) in messages.iter().enumerate() {
+		group.bench_with_input(BenchmarkId::new("to_fix_string", i), message, |b, msg| {
+			b.iter(|| black_box(msg.to_fix_string()))
+		});
+	}
+
+	group.finish();
+}
+
+// Benchmark parsing from FIX string
+fn bench_parsing(c: &mut Criterion) {
+	let mut group = c.benchmark_group("parsing");
+
+	for (i, fix_string) in SAMPLE_FIX_STRINGS.iter().enumerate() {
+		group.bench_with_input(BenchmarkId::new("from_fix_string", i), fix_string, |b, fix_str| {
+			b.iter(|| black_box(FixMessage::from_fix_string(black_box(fix_str))))
+		});
+	}
+
+	group.finish();
+}
+
+// Benchmark round-trip (serialize + parse)
+fn bench_round_trip(c: &mut Criterion) {
+	let messages = create_sample_messages();
+	let mut group = c.benchmark_group("round_trip");
+
+	for (i, message) in messages.iter().enumerate() {
+		group.bench_with_input(BenchmarkId::new("serialize_parse", i), message, |b, msg| {
+			b.iter(|| {
+				let fix_string = black_box(msg.to_fix_string());
+				black_box(FixMessage::from_fix_string(&fix_string))
+			})
+		});
+	}
+
+	group.finish();
+}
+
+// Benchmark enum parsing performance
+fn bench_enum_parsing(c: &mut Criterion) {
+	let mut group = c.benchmark_group("enum_parsing");
+
+	let msg_types = ["0", "1", "D", "8", "F", "G", "V", "W"];
+	let sides = ["1", "2"];
+	let ord_statuses = ["0", "1", "2", "4", "8"];
+
+	group.bench_function("msg_type_parsing", |b| {
+		b.iter(|| {
+			for msg_type_str in &msg_types {
+				let _ = black_box(MsgType::from_str(black_box(msg_type_str)));
+			}
+		})
+	});
+
+	group.bench_function("side_parsing", |b| {
+		b.iter(|| {
+			for side_str in &sides {
+				let _ = black_box(Side::from_str(black_box(side_str)));
+			}
+		})
+	});
+
+	group.bench_function("ord_status_parsing", |b| {
+		b.iter(|| {
+			for status_str in &ord_statuses {
+				let _ = black_box(OrdStatus::from_str(black_box(status_str)));
+			}
+		})
+	});
+
+	group.finish();
+}
+
+// Benchmark field access and manipulation
+fn bench_field_operations(c: &mut Criterion) {
+	let mut group = c.benchmark_group("field_operations");
+
+	let mut message = FixMessage::builder(MsgType::NewOrderSingle, "CLIENT", "BROKER", 100)
+		.cl_ord_id("ORDER123")
+		.symbol("AAPL")
+		.side(Side::Buy)
+		.order_qty(100.0)
+		.price(150.25)
+		.build();
+
+	group.bench_function("set_custom_field", |b| {
+		b.iter(|| {
+			black_box(message.set_field(black_box(9999), black_box("TEST_VALUE")));
+		})
+	});
+
+	group.bench_function("get_custom_field", |b| {
+		message.set_field(9999, "TEST_VALUE");
+		b.iter(|| {
+			black_box(message.get_field(black_box(9999)));
+		})
+	});
+
+	group.bench_function("validation", |b| {
+		b.iter(|| {
+			black_box(message.is_valid());
+		})
+	});
+
+	group.finish();
+}
+
+// Benchmark different message sizes
+fn bench_message_sizes(c: &mut Criterion) {
+	let mut group = c.benchmark_group("message_sizes");
+
+	// Small message (Heartbeat)
+	let small_msg = FixMessage::builder(MsgType::Heartbeat, "A", "B", 1).build();
+
+	// Medium message (New Order Single)
+	let medium_msg = FixMessage::builder(MsgType::NewOrderSingle, "CLIENT", "BROKER", 100)
+		.cl_ord_id("ORDER123")
+		.symbol("AAPL")
+		.side(Side::Buy)
+		.order_qty(100.0)
+		.price(150.25)
+		.build();
+
+	// Large message (with many custom fields)
+	let mut large_msg = FixMessage::builder(MsgType::ExecutionReport, "BROKER", "CLIENT", 100)
+		.order_id("ORDER001")
+		.cl_ord_id("CLIENT001")
+		.exec_id("EXEC001")
+		.exec_type("F")
+		.ord_status(OrdStatus::Filled)
+		.symbol("MSFT")
+		.side(Side::Buy)
+		.order_qty(500.0)
+		.last_px(155.75)
+		.last_qty(500.0)
+		.cum_qty(500.0)
+		.leaves_qty(0.0)
+		.avg_px(155.75)
+		.build();
+
+	// Add many custom fields to make it large
+	for i in 5000..5050 {
+		large_msg.set_field(i, format!("CUSTOM_FIELD_{}", i));
+	}
+
+	group.bench_function("small_message_serialization", |b| b.iter(|| black_box(small_msg.to_fix_string())));
+
+	group.bench_function("medium_message_serialization", |b| b.iter(|| black_box(medium_msg.to_fix_string())));
+
+	group.bench_function("large_message_serialization", |b| b.iter(|| black_box(large_msg.to_fix_string())));
+
+	let small_fix = small_msg.to_fix_string();
+	let medium_fix = medium_msg.to_fix_string();
+	let large_fix = large_msg.to_fix_string();
+
+	group.bench_function("small_message_parsing", |b| {
+		b.iter(|| black_box(FixMessage::from_fix_string(black_box(&small_fix))))
+	});
+
+	group.bench_function("medium_message_parsing", |b| {
+		b.iter(|| black_box(FixMessage::from_fix_string(black_box(&medium_fix))))
+	});
+
+	group.bench_function("large_message_parsing", |b| {
+		b.iter(|| black_box(FixMessage::from_fix_string(black_box(&large_fix))))
+	});
+
+	group.finish();
+}
+
+// Benchmark memory allocation patterns
+fn bench_memory_patterns(c: &mut Criterion) {
+	let mut group = c.benchmark_group("memory_patterns");
+
+	// Benchmark creating many messages in sequence
+	group.bench_function("batch_message_creation", |b| {
+		b.iter(|| {
+			let mut messages = Vec::new();
+			for i in 0..100 {
+				let msg = FixMessage::builder(
+					black_box(MsgType::NewOrderSingle),
+					black_box("CLIENT"),
+					black_box("BROKER"),
+					black_box(i),
+				)
+				.cl_ord_id(black_box(format!("ORDER_{}", i)))
+				.symbol(black_box("AAPL"))
+				.side(black_box(Side::Buy))
+				.order_qty(black_box(100.0))
+				.build();
+				messages.push(msg);
+			}
+			black_box(messages);
+		})
+	});
+
+	// Benchmark reusing builder
+	group.bench_function("builder_reuse_pattern", |b| {
+		b.iter(|| {
+			let mut messages = Vec::new();
+			for i in 0..100 {
+				let msg = FixMessage::builder(
+					black_box(MsgType::NewOrderSingle),
+					black_box("CLIENT"),
+					black_box("BROKER"),
+					black_box(i),
+				)
+				.cl_ord_id(black_box(format!("ORDER_{}", i)))
+				.symbol(black_box("AAPL"))
+				.side(black_box(Side::Buy))
+				.order_qty(black_box(100.0))
+				.build();
+				messages.push(msg);
+			}
+			black_box(messages);
+		})
+	});
+
+	group.finish();
+}
+
+criterion_group!(
+	benches,
+	bench_message_creation,
+	bench_serialization,
+	bench_parsing,
+	bench_round_trip,
+	bench_enum_parsing,
+	bench_field_operations,
+	bench_message_sizes,
+	bench_memory_patterns
+);
+
+criterion_main!(benches);

--- a/run_benchmarks.sh
+++ b/run_benchmarks.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# FIX Benchmarks Runner
+# This script runs all benchmarks and generates reports
+
+set -e
+
+echo "🚀 Running FIX Benchmarks"
+echo "=================================="
+
+# Check if cargo is available
+if ! command -v cargo &> /dev/null; then
+    echo "❌ Cargo not found. Please install Rust and Cargo."
+    exit 1
+fi
+
+# Create benchmarks output directory
+mkdir -p target/criterion
+
+echo "📊 Running core FIX message benchmarks..."
+cargo bench --bench fix_benchmarks
+
+echo ""
+echo "📈 Benchmark reports generated!"
+echo "HTML reports available at:"
+echo "  - target/criterion/report/index.html"
+echo ""
+
+# Check if we can open the report automatically, Linux first
+if command -v xdg-open &> /dev/null; then
+    echo "🌐 Opening benchmark report in browser..."
+    xdg-open target/criterion/report/index.html
+# macOS branch
+elif command -v open &> /dev/null; then
+    echo "🌐 Opening benchmark report in browser..."
+    open target/criterion/report/index.html
+else
+    echo "💡 To view the HTML report, open target/criterion/report/index.html in your browser"
+fi
+
+echo ""
+echo "✅ Benchmarks complete!"
+echo ""
+echo "📝 Quick analysis tips:"
+echo "  - Look for 'message_creation' benchmarks to see constructor overhead"
+echo "  - Check 'serialization' vs 'parsing' performance"
+echo "  - Monitor 'memory_allocation' benchmarks for potential optimizations"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,8 @@ impl FixMessage {
 	) -> Self {
 		Self {
 			begin_string: "FIX.4.2",
+			// TODO: Maybe we can have an enum to represent the length: Empty or Size(u32), or just an Option<u32>.
+			// (I don't like that we initialize this to `0` and only after we set the proper length)
 			body_length: Default::default(), // Will be calculated when serializing
 			msg_type,
 			sender_comp_id: sender_comp_id.into(),
@@ -177,6 +179,7 @@ impl FixMessage {
 			exec_ref_id: None,
 			exec_trans_type: None,
 			additional_fields: BTreeMap::new(),
+			// TODO: Same as the `body_length`, probably we can use a better init strategy.
 			checksum: Cow::Borrowed("000"), // Will be calculated when serializing
 		}
 	}


### PR DESCRIPTION
**Benchmark Infrastructure and Suite:**
- Added a complete Criterion.rs benchmark suite in `benches/fix_benchmarks.rs` covering message creation, serialization, parsing, round-trip performance, enum parsing, field operations, message size impact, and memory allocation patterns.
- Updated `Cargo.toml` to include `criterion` as a development dependency and registered the `fix_benchmarks` benchmark target.

**Documentation and Usability:**
- Added a detailed `benches/README.md` explaining the benchmark suites, key metrics, and how to interpret results, making it easy for developers to understand and extend benchmarking.
- Introduced a `run_benchmarks.sh` script to automate running all benchmarks and opening the HTML report, improving developer workflow.

**Code Quality and Future Improvements:**
- Added TODO comments in `src/lib.rs` suggesting improvements to the initialization strategy for `body_length` and `checksum` fields in `FixMessage`. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R148-R149) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R182)