### PR TITLE
feat: add `ExecutionReport` and `OrderCancelRequestBody` support

### DIFF
--- a/benches/fix_benchmarks.rs
+++ b/benches/fix_benchmarks.rs
@@ -1,6 +1,6 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use fix_learning::{FixMessage, MsgType, OrdStatus, Side};
-use std::{hint::black_box, str::FromStr};
+use std::hint::black_box;
 use time::macros::datetime;
 
 // Sample FIX message data for benchmarks
@@ -53,17 +53,6 @@ fn create_sample_messages() -> Vec<FixMessage> {
 			.side(Side::Sell)
 			.order_qty(100.0)
 			.build(),
-		// Market Data Request
-		// FixMessage::builder(MsgType::MarketDataRequest, "CLIENT", "MARKET", 25)
-		// 	.field(262, "MDREQ001") // MDReqID
-		// 	.field(263, "1") // SubscriptionRequestType
-		// 	.field(264, "20") // MarketDepth
-		// 	.field(267, "2") // NoMDEntryTypes
-		// 	.field(269, "0") // MDEntryType - Bid
-		// 	.field(269, "1") // MDEntryType - Offer
-		// 	.field(146, "1") // NoRelatedSym
-		// 	.symbol("AAPL")
-		// 	.build(),
 	]
 }
 
@@ -197,41 +186,6 @@ fn bench_round_trip(c: &mut Criterion) {
 	group.finish();
 }
 
-// Benchmark enum parsing performance
-fn bench_enum_parsing(c: &mut Criterion) {
-	let mut group = c.benchmark_group("enum_parsing");
-
-	let msg_types = ["0", "1", "D", "8", "F", "G", "V", "W"];
-	let sides = ["1", "2"];
-	let ord_statuses = ["0", "1", "2", "4", "8"];
-
-	group.bench_function("msg_type_parsing", |b| {
-		b.iter(|| {
-			for msg_type_str in &msg_types {
-				let _ = black_box(MsgType::from_str(black_box(msg_type_str)));
-			}
-		})
-	});
-
-	group.bench_function("side_parsing", |b| {
-		b.iter(|| {
-			for side_str in &sides {
-				let _ = black_box(Side::from_str(black_box(side_str)));
-			}
-		})
-	});
-
-	group.bench_function("ord_status_parsing", |b| {
-		b.iter(|| {
-			for status_str in &ord_statuses {
-				let _ = black_box(OrdStatus::from_str(black_box(status_str)));
-			}
-		})
-	});
-
-	group.finish();
-}
-
 // Benchmark field access and manipulation
 fn bench_field_operations(c: &mut Criterion) {
 	let mut group = c.benchmark_group("field_operations");
@@ -270,7 +224,7 @@ fn bench_message_sizes(c: &mut Criterion) {
 		.build();
 
 	// Large message (with many custom fields)
-	let large_msg = FixMessage::builder(MsgType::ExecutionReport, "BROKER", "CLIENT", 100)
+	let large_msg_builder = FixMessage::builder(MsgType::ExecutionReport, "BROKER", "CLIENT", 100)
 		.order_id("ORDER001")
 		.cl_ord_id("CLIENT001")
 		.exec_id("EXEC001")
@@ -282,13 +236,14 @@ fn bench_message_sizes(c: &mut Criterion) {
 		.last_px(155.75)
 		.cum_qty(500.0)
 		.leaves_qty(0.0)
-		.avg_px(155.75)
-		.build();
+		.avg_px(155.75);
 
-	// // Add many custom fields to make it large
+	// Add many custom fields to make it large
 	// for i in 5000..5050 {
-	// 	large_msg.set_field(i, format!("CUSTOM_FIELD_{}", i));
+	// 	large_msg_builder.set_field(i, format!("CUSTOM_FIELD_{}", i));
 	// }
+
+	let large_msg = large_msg_builder.build();
 
 	group.bench_function("small_message_serialization", |b| b.iter(|| black_box(small_msg.to_fix_string())));
 
@@ -298,7 +253,7 @@ fn bench_message_sizes(c: &mut Criterion) {
 
 	let small_fix = small_msg.to_fix_string();
 	let medium_fix = medium_msg.to_fix_string();
-	// let large_fix = large_msg.to_fix_string();
+	let large_fix = large_msg.to_fix_string();
 
 	group.bench_function("small_message_parsing", |b| {
 		b.iter(|| black_box(FixMessage::from_fix_string(black_box(&small_fix))))
@@ -308,9 +263,9 @@ fn bench_message_sizes(c: &mut Criterion) {
 		b.iter(|| black_box(FixMessage::from_fix_string(black_box(&medium_fix))))
 	});
 
-	// group.bench_function("large_message_parsing", |b| {
-	// 	b.iter(|| black_box(FixMessage::from_fix_string(black_box(&large_fix))))
-	// });
+	group.bench_function("large_message_parsing", |b| {
+		b.iter(|| black_box(FixMessage::from_fix_string(black_box(&large_fix))))
+	});
 
 	group.finish();
 }
@@ -372,7 +327,6 @@ criterion_group!(
 	bench_serialization,
 	bench_parsing,
 	bench_round_trip,
-	bench_enum_parsing,
 	bench_field_operations,
 	bench_message_sizes,
 	bench_memory_patterns

--- a/benches/fix_benchmarks.rs
+++ b/benches/fix_benchmarks.rs
@@ -30,31 +30,30 @@ fn create_sample_messages() -> Vec<FixMessage> {
 			.order_qty(100.0)
 			.security_exchange("TO")
 			.build(),
-		// // Execution Report
-		// FixMessage::builder(MsgType::ExecutionReport, "BROKER", "CLIENT", 100)
-		// 	.order_id("ORDER001")
-		// 	.cl_ord_id("CLIENT001")
-		// 	.exec_id("EXEC001")
-		// 	.exec_type("F")
-		// 	.ord_status(OrdStatus::Filled)
-		// 	.symbol("MSFT")
-		// 	.side(Side::Buy)
-		// 	.order_qty(500.0)
-		// 	.last_px(155.75)
-		// 	.last_qty(500.0)
-		// 	.cum_qty(500.0)
-		// 	.leaves_qty(0.0)
-		// 	.avg_px(155.75)
-		// 	.build(),
-		// // Order Cancel Request
-		// FixMessage::builder(MsgType::OrderCancelRequest, "CLIENT", "BROKER", 50)
-		// 	.order_id("ORDER001")
-		// 	.cl_ord_id("CANCEL001")
-		// 	.symbol("GOOGL")
-		// 	.side(Side::Sell)
-		// 	.order_qty(100.0)
-		// 	.build(),
-		// // Market Data Request
+		// Execution Report
+		FixMessage::builder(MsgType::ExecutionReport, "BROKER", "CLIENT", 100)
+			.order_id("ORDER001")
+			.cl_ord_id("CLIENT001")
+			.exec_id("EXEC001")
+			.exec_type("F")
+			.ord_status(OrdStatus::Filled)
+			.symbol("MSFT")
+			.side(Side::Buy)
+			.order_qty(500.0)
+			.last_px(155.75)
+			.cum_qty(500.0)
+			.leaves_qty(0.0)
+			.avg_px(155.75)
+			.build(),
+		// Order Cancel Request
+		FixMessage::builder(MsgType::OrderCancelRequest, "CLIENT", "BROKER", 50)
+			.order_id("ORDER001")
+			.cl_ord_id("CANCEL001")
+			.symbol("GOOGL")
+			.side(Side::Sell)
+			.order_qty(100.0)
+			.build(),
+		// Market Data Request
 		// FixMessage::builder(MsgType::MarketDataRequest, "CLIENT", "MARKET", 25)
 		// 	.field(262, "MDREQ001") // MDReqID
 		// 	.field(263, "1") // SubscriptionRequestType
@@ -125,32 +124,31 @@ fn bench_message_creation(c: &mut Criterion) {
 		})
 	});
 
-	// group.bench_function("execution_report", |b| {
-	// 	b.iter(|| {
-	// 		black_box(
-	// 			FixMessage::builder(
-	// 				black_box(MsgType::ExecutionReport),
-	// 				black_box("BROKER"),
-	// 				black_box("CLIENT"),
-	// 				black_box(100),
-	// 			)
-	// 			.order_id(black_box("ORDER001"))
-	// 			.cl_ord_id(black_box("CLIENT001"))
-	// 			.exec_id(black_box("EXEC001"))
-	// 			.exec_type(black_box("F"))
-	// 			.ord_status(black_box(OrdStatus::Filled))
-	// 			.symbol(black_box("MSFT"))
-	// 			.side(black_box(Side::Buy))
-	// 			.order_qty(black_box(500.0))
-	// 			.last_px(black_box(155.75))
-	// 			.last_qty(black_box(500.0))
-	// 			.cum_qty(black_box(500.0))
-	// 			.leaves_qty(black_box(0.0))
-	// 			.avg_px(black_box(155.75))
-	// 			.build(),
-	// 		)
-	// 	})
-	// });
+	group.bench_function("execution_report", |b| {
+		b.iter(|| {
+			black_box(
+				FixMessage::builder(
+					black_box(MsgType::ExecutionReport),
+					black_box("BROKER"),
+					black_box("CLIENT"),
+					black_box(100),
+				)
+				.order_id(black_box("ORDER001"))
+				.cl_ord_id(black_box("CLIENT001"))
+				.exec_id(black_box("EXEC001"))
+				.exec_type(black_box("F"))
+				.ord_status(black_box(OrdStatus::Filled))
+				.symbol(black_box("MSFT"))
+				.side(black_box(Side::Buy))
+				.order_qty(black_box(500.0))
+				.last_px(black_box(155.75))
+				.cum_qty(black_box(500.0))
+				.leaves_qty(black_box(0.0))
+				.avg_px(black_box(155.75))
+				.build(),
+			)
+		})
+	});
 
 	group.finish();
 }
@@ -271,22 +269,21 @@ fn bench_message_sizes(c: &mut Criterion) {
 		.price(150.25)
 		.build();
 
-	// // Large message (with many custom fields)
-	// let mut large_msg = FixMessage::builder(MsgType::ExecutionReport, "BROKER", "CLIENT", 100)
-	// 	.order_id("ORDER001")
-	// 	.cl_ord_id("CLIENT001")
-	// 	.exec_id("EXEC001")
-	// 	.exec_type("F")
-	// 	.ord_status(OrdStatus::Filled)
-	// 	.symbol("MSFT")
-	// 	.side(Side::Buy)
-	// 	.order_qty(500.0)
-	// 	.last_px(155.75)
-	// 	.last_qty(500.0)
-	// 	.cum_qty(500.0)
-	// 	.leaves_qty(0.0)
-	// 	.avg_px(155.75)
-	// 	.build();
+	// Large message (with many custom fields)
+	let large_msg = FixMessage::builder(MsgType::ExecutionReport, "BROKER", "CLIENT", 100)
+		.order_id("ORDER001")
+		.cl_ord_id("CLIENT001")
+		.exec_id("EXEC001")
+		.exec_type("F")
+		.ord_status(OrdStatus::Filled)
+		.symbol("MSFT")
+		.side(Side::Buy)
+		.order_qty(500.0)
+		.last_px(155.75)
+		.cum_qty(500.0)
+		.leaves_qty(0.0)
+		.avg_px(155.75)
+		.build();
 
 	// // Add many custom fields to make it large
 	// for i in 5000..5050 {
@@ -297,7 +294,7 @@ fn bench_message_sizes(c: &mut Criterion) {
 
 	group.bench_function("medium_message_serialization", |b| b.iter(|| black_box(medium_msg.to_fix_string())));
 
-	// group.bench_function("large_message_serialization", |b| b.iter(|| black_box(large_msg.to_fix_string())));
+	group.bench_function("large_message_serialization", |b| b.iter(|| black_box(large_msg.to_fix_string())));
 
 	let small_fix = small_msg.to_fix_string();
 	let medium_fix = medium_msg.to_fix_string();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -10,7 +10,9 @@ use crate::{
 		EncryptMethod, FixHeader, FixTrailer, MsgType, Side,
 		validation::{FixFieldHandler, WriteTo},
 	},
-	messages::{ExecutionReportBody, FixMessageBody, HeartbeatBody, LogonBody, NewOrderSingleBody},
+	messages::{
+		ExecutionReportBody, FixMessageBody, HeartbeatBody, LogonBody, NewOrderSingleBody, OrderCancelRequestBody,
+	},
 };
 
 use time::OffsetDateTime;
@@ -34,6 +36,7 @@ impl FixMessageBuilder {
 			MsgType::Logon => FixMessageBody::Logon(LogonBody::default()),
 			MsgType::NewOrderSingle => FixMessageBody::NewOrderSingle(NewOrderSingleBody::default()),
 			MsgType::ExecutionReport => FixMessageBody::ExecutionReport(ExecutionReportBody::default()),
+			MsgType::OrderCancelRequest => FixMessageBody::OrderCancelRequest(OrderCancelRequestBody::default()),
 			_ => FixMessageBody::Other,
 		};
 
@@ -215,56 +218,121 @@ impl FixMessageBuilder {
 
 	pub fn exec_trans_type(mut self, v: impl Into<String>) -> Self {
 		if let FixMessageBody::ExecutionReport(body) = &mut self.message.body {
-			body.exec_trans_type = v.into().parse().unwrap_or(body.exec_trans_type.clone());
+			body.exec_trans_type = v.into().parse().unwrap_or_else(|_| body.exec_trans_type.clone());
 		}
 		self
 	}
 
 	pub fn exec_type(mut self, v: impl Into<String>) -> Self {
 		if let FixMessageBody::ExecutionReport(body) = &mut self.message.body {
-			body.exec_type = v.into().parse().unwrap_or(body.exec_type.clone());
+			body.exec_type = v.into().parse().unwrap_or_else(|_| body.exec_type.clone());
 		}
 		self
 	}
 
-	pub fn ord_status(mut self, v: OrdStatus) -> Self {
+	pub const fn ord_status(mut self, v: OrdStatus) -> Self {
 		if let FixMessageBody::ExecutionReport(body) = &mut self.message.body {
 			body.ord_status = v;
 		}
 		self
 	}
 
-	pub fn leaves_qty(mut self, qty: f64) -> Self {
+	pub const fn leaves_qty(mut self, qty: f64) -> Self {
 		if let FixMessageBody::ExecutionReport(body) = &mut self.message.body {
 			body.leaves_qty = qty;
 		}
 		self
 	}
 
-	pub fn cum_qty(mut self, qty: f64) -> Self {
+	pub const fn cum_qty(mut self, qty: f64) -> Self {
 		if let FixMessageBody::ExecutionReport(body) = &mut self.message.body {
 			body.cum_qty = qty;
 		}
 		self
 	}
 
-	pub fn avg_px(mut self, px: f64) -> Self {
+	pub const fn avg_px(mut self, px: f64) -> Self {
 		if let FixMessageBody::ExecutionReport(body) = &mut self.message.body {
 			body.avg_px = px;
 		}
 		self
 	}
 
-	pub fn last_shares(mut self, qty: f64) -> Self {
+	pub const fn last_shares(mut self, qty: f64) -> Self {
 		if let FixMessageBody::ExecutionReport(body) = &mut self.message.body {
 			body.last_shares = Some(qty);
 		}
 		self
 	}
 
-	pub fn last_px(mut self, px: f64) -> Self {
+	pub const fn last_px(mut self, px: f64) -> Self {
 		if let FixMessageBody::ExecutionReport(body) = &mut self.message.body {
 			body.last_px = Some(px);
+		}
+		self
+	}
+
+	// Order Cancel Request setters
+	pub fn orig_cl_ord_id(mut self, v: impl Into<String>) -> Self {
+		if let FixMessageBody::OrderCancelRequest(body) = &mut self.message.body {
+			body.orig_cl_ord_id = v.into();
+		}
+		self
+	}
+
+	pub fn cancel_cl_ord_id(mut self, v: impl Into<String>) -> Self {
+		// alias for cl_ord_id
+		if let FixMessageBody::OrderCancelRequest(body) = &mut self.message.body {
+			body.cl_ord_id = v.into();
+		}
+		self
+	}
+
+	pub fn cancel_symbol(mut self, v: impl Into<String>) -> Self {
+		if let FixMessageBody::OrderCancelRequest(body) = &mut self.message.body {
+			body.symbol = v.into();
+		}
+		self
+	}
+
+	pub const fn cancel_side(mut self, side: Side) -> Self {
+		if let FixMessageBody::OrderCancelRequest(body) = &mut self.message.body {
+			body.side = side;
+		}
+		self
+	}
+
+	pub const fn cancel_transact_time(mut self, t: OffsetDateTime) -> Self {
+		if let FixMessageBody::OrderCancelRequest(body) = &mut self.message.body {
+			body.transact_time = t;
+		}
+		self
+	}
+
+	pub const fn cancel_order_qty(mut self, q: f64) -> Self {
+		if let FixMessageBody::OrderCancelRequest(body) = &mut self.message.body {
+			body.order_qty = Some(q);
+		}
+		self
+	}
+
+	pub const fn cancel_cash_order_qty(mut self, q: f64) -> Self {
+		if let FixMessageBody::OrderCancelRequest(body) = &mut self.message.body {
+			body.cash_order_qty = Some(q);
+		}
+		self
+	}
+
+	pub fn cancel_account(mut self, v: impl Into<String>) -> Self {
+		if let FixMessageBody::OrderCancelRequest(body) = &mut self.message.body {
+			body.account = Some(v.into());
+		}
+		self
+	}
+
+	pub fn cancel_text(mut self, v: impl Into<String>) -> Self {
+		if let FixMessageBody::OrderCancelRequest(body) = &mut self.message.body {
+			body.text = Some(v.into());
 		}
 		self
 	}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,12 +5,12 @@
 //! body length calculation and checksum generation.
 
 use crate::{
-	FixMessage,
+	FixMessage, OrdStatus,
 	common::{
 		EncryptMethod, FixHeader, FixTrailer, MsgType, Side,
 		validation::{FixFieldHandler, WriteTo},
 	},
-	messages::{FixMessageBody, HeartbeatBody, LogonBody, NewOrderSingleBody},
+	messages::{ExecutionReportBody, FixMessageBody, HeartbeatBody, LogonBody, NewOrderSingleBody},
 };
 
 use time::OffsetDateTime;
@@ -33,6 +33,7 @@ impl FixMessageBuilder {
 			MsgType::Heartbeat => FixMessageBody::Heartbeat(HeartbeatBody::default()),
 			MsgType::Logon => FixMessageBody::Logon(LogonBody::default()),
 			MsgType::NewOrderSingle => FixMessageBody::NewOrderSingle(NewOrderSingleBody::default()),
+			MsgType::ExecutionReport => FixMessageBody::ExecutionReport(ExecutionReportBody::default()),
 			_ => FixMessageBody::Other,
 		};
 
@@ -193,6 +194,77 @@ impl FixMessageBuilder {
 	pub const fn price(mut self, price: f64) -> Self {
 		if let FixMessageBody::NewOrderSingle(body) = &mut self.message.body {
 			body.price = Some(price);
+		}
+		self
+	}
+
+	// Execution Report setters (minimal subset)
+	pub fn order_id(mut self, order_id: impl Into<String>) -> Self {
+		if let FixMessageBody::ExecutionReport(body) = &mut self.message.body {
+			body.order_id = order_id.into();
+		}
+		self
+	}
+
+	pub fn exec_id(mut self, exec_id: impl Into<String>) -> Self {
+		if let FixMessageBody::ExecutionReport(body) = &mut self.message.body {
+			body.exec_id = exec_id.into();
+		}
+		self
+	}
+
+	pub fn exec_trans_type(mut self, v: impl Into<String>) -> Self {
+		if let FixMessageBody::ExecutionReport(body) = &mut self.message.body {
+			body.exec_trans_type = v.into().parse().unwrap_or(body.exec_trans_type.clone());
+		}
+		self
+	}
+
+	pub fn exec_type(mut self, v: impl Into<String>) -> Self {
+		if let FixMessageBody::ExecutionReport(body) = &mut self.message.body {
+			body.exec_type = v.into().parse().unwrap_or(body.exec_type.clone());
+		}
+		self
+	}
+
+	pub fn ord_status(mut self, v: OrdStatus) -> Self {
+		if let FixMessageBody::ExecutionReport(body) = &mut self.message.body {
+			body.ord_status = v;
+		}
+		self
+	}
+
+	pub fn leaves_qty(mut self, qty: f64) -> Self {
+		if let FixMessageBody::ExecutionReport(body) = &mut self.message.body {
+			body.leaves_qty = qty;
+		}
+		self
+	}
+
+	pub fn cum_qty(mut self, qty: f64) -> Self {
+		if let FixMessageBody::ExecutionReport(body) = &mut self.message.body {
+			body.cum_qty = qty;
+		}
+		self
+	}
+
+	pub fn avg_px(mut self, px: f64) -> Self {
+		if let FixMessageBody::ExecutionReport(body) = &mut self.message.body {
+			body.avg_px = px;
+		}
+		self
+	}
+
+	pub fn last_shares(mut self, qty: f64) -> Self {
+		if let FixMessageBody::ExecutionReport(body) = &mut self.message.body {
+			body.last_shares = Some(qty);
+		}
+		self
+	}
+
+	pub fn last_px(mut self, px: f64) -> Self {
+		if let FixMessageBody::ExecutionReport(body) = &mut self.message.body {
+			body.last_px = Some(px);
 		}
 		self
 	}

--- a/src/common/enums.rs
+++ b/src/common/enums.rs
@@ -41,6 +41,37 @@ fix_enum!(Strict OrdStatus {
 	PendingReplace     => "E",
 });
 
+// ExecType (Tag 150) extends OrdStatus semantics with additional values for trade events & restatements
+fix_enum!(Strict ExecType {
+	New             => "0",
+	PartialFill     => "1",
+	Fill            => "2",
+	DoneForDay      => "3",
+	Canceled        => "4",
+	Replaced        => "5",
+	PendingCancel   => "6",
+	Stopped         => "7",
+	Rejected        => "8",
+	Suspended       => "9",
+	PendingNew      => "A",
+	Calculated      => "B",
+	Expired         => "C",
+	Restated        => "D",
+	PendingReplace  => "E",
+	Trade           => "F", // (partial fill or fill)
+	TradeCorrect    => "G",
+	TradeCancel     => "H",
+	OrderStatus     => "I",
+});
+
+// ExecTransType (Tag 20)
+fix_enum!(Strict ExecTransType {
+	New     => "0",
+	Cancel  => "1",
+	Correct => "2",
+	Status  => "3",
+});
+
 // FIX 4.2 Encryption Methods for Logon messages
 fix_enum!(Strict EncryptMethod {
 	None => "0",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub use builder::FixMessageBuilder;
 pub use common::{
 	EncryptMethod, FixHeader, FixTrailer, MsgType, OrdStatus, SOH, Side, Validate, ValidationError, parse_fix_timestamp,
 };
-pub use messages::{FixMessageBody, HeartbeatBody, LogonBody, NewOrderSingleBody};
+pub use messages::{ExecutionReportBody, FixMessageBody, HeartbeatBody, LogonBody, NewOrderSingleBody};
 
 use crate::common::validation::{FixFieldHandler, WriteTo};
 
@@ -103,6 +103,7 @@ impl FixMessage {
 			MsgType::Heartbeat => FixMessageBody::Heartbeat(HeartbeatBody::default()),
 			MsgType::Logon => FixMessageBody::Logon(LogonBody::default()),
 			MsgType::NewOrderSingle => FixMessageBody::NewOrderSingle(NewOrderSingleBody::default()),
+			MsgType::ExecutionReport => FixMessageBody::ExecutionReport(ExecutionReportBody::default()),
 			_ => FixMessageBody::Other,
 		};
 		let header = FixHeader::new(msg_type, sender_comp_id, target_comp_id, msg_seq_num);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,9 @@ pub use builder::FixMessageBuilder;
 pub use common::{
 	EncryptMethod, FixHeader, FixTrailer, MsgType, OrdStatus, SOH, Side, Validate, ValidationError, parse_fix_timestamp,
 };
-pub use messages::{ExecutionReportBody, FixMessageBody, HeartbeatBody, LogonBody, NewOrderSingleBody};
+pub use messages::{
+	ExecutionReportBody, FixMessageBody, HeartbeatBody, LogonBody, NewOrderSingleBody, OrderCancelRequestBody,
+};
 
 use crate::common::validation::{FixFieldHandler, WriteTo};
 
@@ -104,6 +106,7 @@ impl FixMessage {
 			MsgType::Logon => FixMessageBody::Logon(LogonBody::default()),
 			MsgType::NewOrderSingle => FixMessageBody::NewOrderSingle(NewOrderSingleBody::default()),
 			MsgType::ExecutionReport => FixMessageBody::ExecutionReport(ExecutionReportBody::default()),
+			MsgType::OrderCancelRequest => FixMessageBody::OrderCancelRequest(OrderCancelRequestBody::default()),
 			_ => FixMessageBody::Other,
 		};
 		let header = FixHeader::new(msg_type, sender_comp_id, target_comp_id, msg_seq_num);

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -13,7 +13,7 @@ use crate::common::{
 };
 
 // Re-export message body types
-pub use order::{ExecutionReportBody, NewOrderSingleBody};
+pub use order::{ExecutionReportBody, NewOrderSingleBody, OrderCancelRequestBody};
 pub use session::{HeartbeatBody, LogonBody};
 
 /// Message-specific body that only allocates fields needed for each message type
@@ -31,6 +31,8 @@ pub enum FixMessageBody {
 	NewOrderSingle(NewOrderSingleBody),
 	/// Execution Report message body (MsgType=8)
 	ExecutionReport(ExecutionReportBody),
+	/// Order Cancel Request message body (MsgType=F)
+	OrderCancelRequest(OrderCancelRequestBody),
 	/// Placeholder for other message types not yet implemented with specific bodies
 	Other,
 }
@@ -42,6 +44,7 @@ impl Validate for FixMessageBody {
 			Self::Logon(body) => body.validate(),
 			Self::NewOrderSingle(body) => body.validate(),
 			Self::ExecutionReport(body) => body.validate(),
+			Self::OrderCancelRequest(body) => body.validate(),
 			Self::Other => Ok(()), // No validation for unsupported types yet
 		}
 	}
@@ -54,6 +57,7 @@ impl WriteTo for FixMessageBody {
 			Self::Logon(body) => body.write_to(buffer),
 			Self::NewOrderSingle(body) => body.write_to(buffer),
 			Self::ExecutionReport(body) => body.write_to(buffer),
+			Self::OrderCancelRequest(body) => body.write_to(buffer),
 			Self::Other => unimplemented!(),
 		}
 	}
@@ -66,6 +70,7 @@ impl FixFieldHandler for FixMessageBody {
 			Self::Logon(body) => body.parse_field(tag, value),
 			Self::NewOrderSingle(body) => body.parse_field(tag, value),
 			Self::ExecutionReport(body) => body.parse_field(tag, value),
+			Self::OrderCancelRequest(body) => body.parse_field(tag, value),
 			Self::Other => Ok(()), // Ignore fields for unsupported types
 		}
 	}

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -13,7 +13,7 @@ use crate::common::{
 };
 
 // Re-export message body types
-pub use order::NewOrderSingleBody;
+pub use order::{ExecutionReportBody, NewOrderSingleBody};
 pub use session::{HeartbeatBody, LogonBody};
 
 /// Message-specific body that only allocates fields needed for each message type
@@ -29,6 +29,8 @@ pub enum FixMessageBody {
 	Logon(LogonBody),
 	/// New Order Single message body (MsgType=D)
 	NewOrderSingle(NewOrderSingleBody),
+	/// Execution Report message body (MsgType=8)
+	ExecutionReport(ExecutionReportBody),
 	/// Placeholder for other message types not yet implemented with specific bodies
 	Other,
 }
@@ -39,6 +41,7 @@ impl Validate for FixMessageBody {
 			Self::Heartbeat(body) => body.validate(),
 			Self::Logon(body) => body.validate(),
 			Self::NewOrderSingle(body) => body.validate(),
+			Self::ExecutionReport(body) => body.validate(),
 			Self::Other => Ok(()), // No validation for unsupported types yet
 		}
 	}
@@ -50,6 +53,7 @@ impl WriteTo for FixMessageBody {
 			Self::Heartbeat(body) => body.write_to(buffer),
 			Self::Logon(body) => body.write_to(buffer),
 			Self::NewOrderSingle(body) => body.write_to(buffer),
+			Self::ExecutionReport(body) => body.write_to(buffer),
 			Self::Other => unimplemented!(),
 		}
 	}
@@ -61,6 +65,7 @@ impl FixFieldHandler for FixMessageBody {
 			Self::Heartbeat(body) => body.parse_field(tag, value),
 			Self::Logon(body) => body.parse_field(tag, value),
 			Self::NewOrderSingle(body) => body.parse_field(tag, value),
+			Self::ExecutionReport(body) => body.parse_field(tag, value),
 			Self::Other => Ok(()), // Ignore fields for unsupported types
 		}
 	}

--- a/src/messages/order/executionreport.rs
+++ b/src/messages/order/executionreport.rs
@@ -1,0 +1,216 @@
+//! Execution Report message implementation (MsgType=8)
+//!
+//! This module implements a minimal subset of the FIX 4.2 Execution Report message.
+//! It focuses on the core required fields to acknowledge order state and fills.
+//! The full specification is extensive; this struct can be extended incrementally.
+
+use crate::{
+	OrdStatus, SOH, Side,
+	common::{
+		Validate, ValidationError,
+		enums::{ExecTransType, ExecType},
+		parse_fix_timestamp,
+		validation::{FixFieldHandler, WriteTo},
+		write_tag_timestamp,
+	},
+};
+use std::fmt::Write;
+use time::OffsetDateTime;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExecutionReportBody {
+	// (Tag 37) Required
+	pub order_id: String,
+	// (Tag 17) Required
+	pub exec_id: String,
+	// (Tag 20) Required
+	pub exec_trans_type: ExecTransType,
+	// (Tag 150) Required
+	pub exec_type: ExecType,
+	// (Tag 39) Required
+	pub ord_status: OrdStatus,
+	// (Tag 55) Required
+	pub symbol: String,
+	// (Tag 54) Required
+	pub side: Side,
+	// (Tag 151) Required
+	pub leaves_qty: f64,
+	// (Tag 14) Required
+	pub cum_qty: f64,
+	// (Tag 6) Required
+	pub avg_px: f64,
+	// (Tag 32) Optional (Qty of last fill)
+	pub last_shares: Option<f64>,
+	// (Tag 31) Optional (Px of last fill)
+	pub last_px: Option<f64>,
+	// (Tag 60) Optional TransactTime
+	pub transact_time: Option<OffsetDateTime>,
+	// (Tag 11) Optional ClOrdID for linkage
+	pub cl_ord_id: Option<String>,
+	// (Tag 41) Optional OrigClOrdID
+	pub orig_cl_ord_id: Option<String>,
+	// (Tag 103) Optional OrdRejReason when Rejected
+	pub ord_rej_reason: Option<u32>,
+}
+
+impl Default for ExecutionReportBody {
+	fn default() -> Self {
+		Self {
+			order_id: String::new(),
+			exec_id: String::new(),
+			exec_trans_type: ExecTransType::New,
+			exec_type: ExecType::New,
+			ord_status: OrdStatus::New,
+			symbol: String::new(),
+			side: Side::Buy,
+			leaves_qty: 0.0,
+			cum_qty: 0.0,
+			avg_px: 0.0,
+			last_shares: None,
+			last_px: None,
+			transact_time: None,
+			cl_ord_id: None,
+			orig_cl_ord_id: None,
+			ord_rej_reason: None,
+		}
+	}
+}
+
+impl Validate for ExecutionReportBody {
+	fn validate(&self) -> Result<(), ValidationError> {
+		if self.order_id.is_empty() {
+			return Err(ValidationError::MissingRequiredField("OrderID".into()));
+		}
+		if self.exec_id.is_empty() {
+			return Err(ValidationError::MissingRequiredField("ExecID".into()));
+		}
+		if self.symbol.is_empty() {
+			return Err(ValidationError::MissingRequiredField("Symbol".into()));
+		}
+		// LeavesQty + CumQty consistency (cannot be negative; allow zero for terminal states)
+		if self.leaves_qty < 0.0 {
+			return Err(ValidationError::InvalidFieldValue("LeavesQty".into(), self.leaves_qty.to_string()));
+		}
+		if self.cum_qty < 0.0 {
+			return Err(ValidationError::InvalidFieldValue("CumQty".into(), self.cum_qty.to_string()));
+		}
+		if self.avg_px < 0.0 {
+			return Err(ValidationError::InvalidFieldValue("AvgPx".into(), self.avg_px.to_string()));
+		}
+		Ok(())
+	}
+}
+
+impl WriteTo for ExecutionReportBody {
+	fn write_to(&self, buffer: &mut String) {
+		write!(buffer, "37={}{}", self.order_id, SOH).unwrap();
+		write!(buffer, "17={}{}", self.exec_id, SOH).unwrap();
+		write!(buffer, "20={}{}", self.exec_trans_type, SOH).unwrap();
+		write!(buffer, "150={}{}", self.exec_type, SOH).unwrap();
+		write!(buffer, "39={}{}", self.ord_status, SOH).unwrap();
+		if let Some(ref cl) = self.cl_ord_id {
+			write!(buffer, "11={}{}", cl, SOH).unwrap();
+		}
+		if let Some(ref orig) = self.orig_cl_ord_id {
+			write!(buffer, "41={}{}", orig, SOH).unwrap();
+		}
+		write!(buffer, "55={}{}", self.symbol, SOH).unwrap();
+		write!(buffer, "54={}{}", self.side, SOH).unwrap();
+		if let Some(ts) = self.transact_time {
+			write_tag_timestamp(buffer, 60, ts);
+		}
+		if let Some(qty) = self.last_shares {
+			write!(buffer, "32={}{}", qty, SOH).unwrap();
+		}
+		if let Some(px) = self.last_px {
+			write!(buffer, "31={}{}", px, SOH).unwrap();
+		}
+		write!(buffer, "151={}{}", self.leaves_qty, SOH).unwrap();
+		write!(buffer, "14={}{}", self.cum_qty, SOH).unwrap();
+		write!(buffer, "6={}{}", self.avg_px, SOH).unwrap();
+		if let Some(reason) = self.ord_rej_reason {
+			write!(buffer, "103={}{}", reason, SOH).unwrap();
+		}
+	}
+}
+
+impl ExecutionReportBody {
+	pub fn new(order_id: impl Into<String>, exec_id: impl Into<String>) -> Self {
+		Self { order_id: order_id.into(), exec_id: exec_id.into(), ..Default::default() }
+	}
+}
+
+impl FixFieldHandler for ExecutionReportBody {
+	fn parse_field(&mut self, tag: u32, value: &str) -> Result<(), String> {
+		match tag {
+			37 => self.order_id = value.to_string(),
+			17 => self.exec_id = value.to_string(),
+			20 => self.exec_trans_type = value.parse().map_err(|_| "Invalid ExecTransType")?,
+			150 => self.exec_type = value.parse().map_err(|_| "Invalid ExecType")?,
+			39 => self.ord_status = value.parse().map_err(|_| "Invalid OrdStatus")?,
+			55 => self.symbol = value.to_string(),
+			54 => self.side = value.parse().map_err(|_| "Invalid Side")?,
+			151 => self.leaves_qty = value.parse().map_err(|_| "Invalid LeavesQty")?,
+			14 => self.cum_qty = value.parse().map_err(|_| "Invalid CumQty")?,
+			6 => self.avg_px = value.parse().map_err(|_| "Invalid AvgPx")?,
+			32 => self.last_shares = Some(value.parse().map_err(|_| "Invalid LastShares")?),
+			31 => self.last_px = Some(value.parse().map_err(|_| "Invalid LastPx")?),
+			60 => self.transact_time = Some(parse_fix_timestamp(value)?),
+			11 => self.cl_ord_id = Some(value.to_string()),
+			41 => self.orig_cl_ord_id = Some(value.to_string()),
+			103 => self.ord_rej_reason = Some(value.parse().map_err(|_| "Invalid OrdRejReason")?),
+			_ => return Err(format!("Unknown execution report field: {}", tag)),
+		}
+		Ok(())
+	}
+
+	fn write_body_fields(&self, buffer: &mut String) {
+		self.write_to(buffer);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_basic_execution_report_validation() {
+		let body = ExecutionReportBody {
+			order_id: "OID".into(),
+			exec_id: "EID".into(),
+			symbol: "AAPL".into(),
+			side: Side::Buy,
+			leaves_qty: 50.0,
+			cum_qty: 50.0,
+			avg_px: 150.25,
+			..Default::default()
+		};
+		assert!(body.validate().is_ok());
+	}
+
+	#[test]
+	fn test_missing_required_fields() {
+		let body = ExecutionReportBody::default();
+		assert!(body.validate().is_err());
+	}
+
+	#[test]
+	fn test_parse_and_write_roundtrip() {
+		let mut body = ExecutionReportBody::default();
+		assert!(body.parse_field(37, "OID1").is_ok());
+		assert!(body.parse_field(17, "EID1").is_ok());
+		assert!(body.parse_field(20, "0").is_ok());
+		assert!(body.parse_field(150, "0").is_ok());
+		assert!(body.parse_field(39, "0").is_ok());
+		assert!(body.parse_field(55, "MSFT").is_ok());
+		assert!(body.parse_field(54, "1").is_ok());
+		assert!(body.parse_field(151, "100").is_ok());
+		assert!(body.parse_field(14, "0").is_ok());
+		assert!(body.parse_field(6, "0").is_ok());
+		assert!(body.validate().is_ok());
+		let mut s = String::new();
+		body.write_to(&mut s);
+		assert!(s.contains("37=OID1"));
+		assert!(s.contains("150=0"));
+	}
+}

--- a/src/messages/order/mod.rs
+++ b/src/messages/order/mod.rs
@@ -1,6 +1,8 @@
 pub mod executionreport;
 pub mod newordersingle;
+pub mod ordercancelrequest;
 
 // Re-export message body types for convenience
 pub use executionreport::ExecutionReportBody;
 pub use newordersingle::NewOrderSingleBody;
+pub use ordercancelrequest::OrderCancelRequestBody;

--- a/src/messages/order/mod.rs
+++ b/src/messages/order/mod.rs
@@ -1,4 +1,6 @@
+pub mod executionreport;
 pub mod newordersingle;
 
 // Re-export message body types for convenience
+pub use executionreport::ExecutionReportBody;
 pub use newordersingle::NewOrderSingleBody;

--- a/src/messages/order/ordercancelrequest.rs
+++ b/src/messages/order/ordercancelrequest.rs
@@ -1,0 +1,153 @@
+//! Order Cancel Request message implementation (MsgType=F)
+//!
+//! Minimal FIX 4.2 Order Cancel Request supporting core required fields:
+//! OrigClOrdID(41), ClOrdID(11), Symbol(55), Side(54), TransactTime(60)
+//! with optional OrderID(37), OrderQty(38)/CashOrderQty(152), Account(1), Text(58).
+
+use crate::{
+	SOH, Side,
+	common::{
+		Validate, ValidationError, parse_fix_timestamp,
+		validation::{FixFieldHandler, WriteTo},
+		write_tag_timestamp,
+	},
+};
+use std::fmt::Write;
+use time::OffsetDateTime;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OrderCancelRequestBody {
+	pub orig_cl_ord_id: String,        // 41 Required
+	pub cl_ord_id: String,             // 11 Required (unique id of this cancel request)
+	pub symbol: String,                // 55 Required
+	pub side: Side,                    // 54 Required
+	pub transact_time: OffsetDateTime, // 60 Required
+	pub order_id: Option<String>,      // 37 Optional (most recent order id as assigned by broker)
+	pub order_qty: Option<f64>,        // 38 Either this or cash_order_qty required (per spec)
+	pub cash_order_qty: Option<f64>,   // 152
+	pub account: Option<String>,       // 1 Optional
+	pub text: Option<String>,          // 58 Optional
+}
+
+impl Default for OrderCancelRequestBody {
+	fn default() -> Self {
+		Self {
+			orig_cl_ord_id: String::new(),
+			cl_ord_id: String::new(),
+			symbol: String::new(),
+			side: Side::Buy,
+			transact_time: OffsetDateTime::now_utc(),
+			order_id: None,
+			order_qty: None,
+			cash_order_qty: None,
+			account: None,
+			text: None,
+		}
+	}
+}
+
+impl Validate for OrderCancelRequestBody {
+	fn validate(&self) -> Result<(), ValidationError> {
+		if self.orig_cl_ord_id.is_empty() {
+			return Err(ValidationError::MissingRequiredField("OrigClOrdID".into()));
+		}
+		if self.cl_ord_id.is_empty() {
+			return Err(ValidationError::MissingRequiredField("ClOrdID".into()));
+		}
+		if self.symbol.is_empty() {
+			return Err(ValidationError::MissingRequiredField("Symbol".into()));
+		}
+		// OrderQty or CashOrderQty required per spec (treat as required here)
+		if self.order_qty.is_none() && self.cash_order_qty.is_none() {
+			return Err(ValidationError::MissingRequiredField("OrderQty or CashOrderQty".into()));
+		}
+		Ok(())
+	}
+}
+
+impl WriteTo for OrderCancelRequestBody {
+	fn write_to(&self, buffer: &mut String) {
+		// Required first
+		write!(buffer, "41={}{}", self.orig_cl_ord_id, SOH).unwrap();
+		if let Some(ref oid) = self.order_id {
+			write!(buffer, "37={}{}", oid, SOH).unwrap();
+		}
+		write!(buffer, "11={}{}", self.cl_ord_id, SOH).unwrap();
+		write!(buffer, "55={}{}", self.symbol, SOH).unwrap();
+		write!(buffer, "54={}{}", self.side, SOH).unwrap();
+		write_tag_timestamp(buffer, 60, self.transact_time);
+		if let Some(qty) = self.order_qty {
+			write!(buffer, "38={}{}", qty, SOH).unwrap();
+		}
+		if let Some(cash) = self.cash_order_qty {
+			write!(buffer, "152={}{}", cash, SOH).unwrap();
+		}
+		if let Some(ref acct) = self.account {
+			write!(buffer, "1={}{}", acct, SOH).unwrap();
+		}
+		if let Some(ref txt) = self.text {
+			write!(buffer, "58={}{}", txt, SOH).unwrap();
+		}
+	}
+}
+
+impl FixFieldHandler for OrderCancelRequestBody {
+	fn parse_field(&mut self, tag: u32, value: &str) -> Result<(), String> {
+		match tag {
+			41 => self.orig_cl_ord_id = value.to_string(),
+			37 => self.order_id = Some(value.to_string()),
+			11 => self.cl_ord_id = value.to_string(),
+			55 => self.symbol = value.to_string(),
+			54 => self.side = value.parse().map_err(|_| "Invalid Side")?,
+			60 => self.transact_time = parse_fix_timestamp(value)?,
+			38 => self.order_qty = Some(value.parse().map_err(|_| "Invalid OrderQty")?),
+			152 => self.cash_order_qty = Some(value.parse().map_err(|_| "Invalid CashOrderQty")?),
+			1 => self.account = Some(value.to_string()),
+			58 => self.text = Some(value.to_string()),
+			_ => return Err(format!("Unknown order cancel request field: {}", tag)),
+		}
+		Ok(())
+	}
+
+	fn write_body_fields(&self, buffer: &mut String) {
+		self.write_to(buffer);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_validation_missing_required() {
+		let body = OrderCancelRequestBody::default();
+		assert!(body.validate().is_err());
+	}
+
+	#[test]
+	fn test_validation_success() {
+		let mut body = OrderCancelRequestBody::default();
+		body.orig_cl_ord_id = "ORIG1".into();
+		body.cl_ord_id = "CXL1".into();
+		body.symbol = "AAPL".into();
+		body.order_qty = Some(100.0);
+		assert!(body.validate().is_ok());
+	}
+
+	#[test]
+	fn test_parse_and_write() {
+		let mut body = OrderCancelRequestBody::default();
+		body.parse_field(41, "ORIG1").unwrap();
+		body.parse_field(11, "CXL1").unwrap();
+		body.parse_field(55, "MSFT").unwrap();
+		body.parse_field(54, "1").unwrap();
+		body.parse_field(38, "50").unwrap();
+		body.parse_field(60, "20240101-12:00:00.000").unwrap();
+		assert!(body.validate().is_ok());
+		let mut s = String::new();
+		body.write_to(&mut s);
+		assert!(s.contains("41=ORIG1"));
+		assert!(s.contains("11=CXL1"));
+		assert!(s.contains("38=50"));
+	}
+}


### PR DESCRIPTION
This pull request adds structured support for the Execution Report (MsgType=8) and Order Cancel Request (MsgType=F) message types to the FIX engine, including their strongly-typed bodies, builder methods, and integration into parsing, serialization, and validation. It also enhances the benchmarking suite to cover these new message types and introduces enums for ExecType and ExecTransType. 

**Core message type support:**

* Added `ExecutionReportBody` and `OrderCancelRequestBody` types, and integrated them into the `FixMessageBody` enum, allowing for strongly-typed handling of Execution Report and Order Cancel Request messages. (`src/messages/mod.rs`, `src/lib.rs`, `src/builder.rs`, [[1]](diffhunk://#diff-d8f793d3966f695eb67921b1abc44ce63056dbfdab91b6364d515c1e5fe3f57cR32-R35) [[2]](diffhunk://#diff-d8f793d3966f695eb67921b1abc44ce63056dbfdab91b6364d515c1e5fe3f57cR46-R47) [[3]](diffhunk://#diff-d8f793d3966f695eb67921b1abc44ce63056dbfdab91b6364d515c1e5fe3f57cR59-R60) [[4]](diffhunk://#diff-d8f793d3966f695eb67921b1abc44ce63056dbfdab91b6364d515c1e5fe3f57cR72-R73) [[5]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L56-R58) [[6]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R108-R109) [[7]](diffhunk://#diff-e4f794ca308aa712cbad31feb714df7cada1bbe453a30e232e45891571430263L8-R15) [[8]](diffhunk://#diff-e4f794ca308aa712cbad31feb714df7cada1bbe453a30e232e45891571430263R38-R39)
* Implemented builder methods for Execution Report (e.g., `order_id`, `exec_id`, `exec_type`, etc.) and Order Cancel Request (e.g., `orig_cl_ord_id`, `cancel_cl_ord_id`, etc.) in `FixMessageBuilder` for ergonomic message construction. (`src/builder.rs`, [src/builder.rsR204-R339](diffhunk://#diff-e4f794ca308aa712cbad31feb714df7cada1bbe453a30e232e45891571430263R204-R339))

**Enum and parsing enhancements:**

* Introduced strict enums for `ExecType` (Tag 150) and `ExecTransType` (Tag 20), providing type safety and clarity for these fields in Execution Reports. (`src/common/enums.rs`, [src/common/enums.rsR44-R74](diffhunk://#diff-db646cd848cd9eed1cb0de59688e61a033d85aafe130d7d5ef8ba96bae0a9e7fR44-R74))

**Benchmark improvements:**

* Updated the benchmarking suite to include Execution Report and Order Cancel Request messages in sample data and enabled benchmarks for their creation, serialization, and parsing, including large message scenarios. (`benches/fix_benchmarks.rs`, [[1]](diffhunk://#diff-46ca72afcda37ee33193759216cdab3ecfe601214ba6f6d30b1ed56ba97075d4L33-R55) [[2]](diffhunk://#diff-46ca72afcda37ee33193759216cdab3ecfe601214ba6f6d30b1ed56ba97075d4L128-R140) [[3]](diffhunk://#diff-46ca72afcda37ee33193759216cdab3ecfe601214ba6f6d30b1ed56ba97075d4L274-R256) [[4]](diffhunk://#diff-46ca72afcda37ee33193759216cdab3ecfe601214ba6f6d30b1ed56ba97075d4L314-R268)
* Removed the now-unnecessary `bench_enum_parsing` as enum parsing is now handled by the new strict enums and message bodies. (`benches/fix_benchmarks.rs`, [[1]](diffhunk://#diff-46ca72afcda37ee33193759216cdab3ecfe601214ba6f6d30b1ed56ba97075d4L202-L236) [[2]](diffhunk://#diff-46ca72afcda37ee33193759216cdab3ecfe601214ba6f6d30b1ed56ba97075d4L378)